### PR TITLE
fix: correct FeatureEvaluationContext and EnvironmentType Enum

### DIFF
--- a/FeatureFlag.Domain/Enums/EnvironmentType.cs
+++ b/FeatureFlag.Domain/Enums/EnvironmentType.cs
@@ -2,7 +2,8 @@ namespace FeatureFlag.Domain.Enums;
 
 public enum EnvironmentType
 {
+    None = 0,
     Development,
     Staging,
-    Production
+    Production,
 }

--- a/FeatureFlag.Domain/ValueObjects/FeatureEvaluationContext.cs
+++ b/FeatureFlag.Domain/ValueObjects/FeatureEvaluationContext.cs
@@ -1,18 +1,47 @@
+using FeatureFlag.Domain.Enums;
+
 namespace FeatureFlag.Domain.ValueObjects;
 
-public sealed class FeatureEvaluationContext
+public sealed class FeatureEvaluationContext : IEquatable<FeatureEvaluationContext>
 {
     public string UserId { get; }
     public IReadOnlyList<string> UserRoles { get; }
-    public Enums.EnvironmentType Environment { get; }
+    public EnvironmentType Environment { get; }
 
-    public FeatureEvaluationContext(string userId, IEnumerable<string> userRoles, Enums.EnvironmentType environment)
+    public FeatureEvaluationContext(
+        string userId,
+        IEnumerable<string> userRoles,
+        EnvironmentType environment
+    )
     {
         if (string.IsNullOrWhiteSpace(userId))
             throw new ArgumentException("UserId cannot be empty.", nameof(userId));
+
+        if (!Enum.IsDefined(environment) || environment == EnvironmentType.None)
+            throw new ArgumentException(
+                "A valid environment must be specified.",
+                nameof(environment)
+            );
 
         UserId = userId;
         UserRoles = (userRoles ?? Enumerable.Empty<string>()).ToList().AsReadOnly();
         Environment = environment;
     }
+
+    public bool Equals(FeatureEvaluationContext? other)
+    {
+        if (other is null)
+            return false;
+        if (ReferenceEquals(this, other))
+            return true;
+
+        return UserId == other.UserId
+            && Environment == other.Environment
+            && UserRoles.SequenceEqual(other.UserRoles);
+    }
+
+    public override bool Equals(object? obj) => Equals(obj as FeatureEvaluationContext);
+
+    public override int GetHashCode() =>
+        HashCode.Combine(UserId, Environment, UserRoles.Aggregate(0, HashCode.Combine));
 }


### PR DESCRIPTION
Fixes several issues identified in the domain layer:

- Add None = 0 sentinel to EnvironmentType to prevent silent default evaluation
- Add enum guard in FeatureEvaluationContext constructor to reject None and undefined values
- Implement IEquatable<FeatureEvaluationContext> for correct value-based equality
- Override Equals(object) and GetHashCode to ensure equality is respected across the .NET ecosystem
- Replace inline namespace qualifier with proper using statement