### PR TITLE
refactor: rename FeatureFlag entity to Flag to resolve namespace collision

### DIFF
--- a/FeatureFlag.Domain/Entities/Flag.cs
+++ b/FeatureFlag.Domain/Entities/Flag.cs
@@ -2,7 +2,7 @@ using FeatureFlag.Domain.Enums;
 
 namespace FeatureFlag.Domain.Entities;
 
-public class FeatureFlag
+public class Flag
 {
     public Guid Id { get; private set; } = Guid.NewGuid();
     public string Name { get; private set; }
@@ -15,7 +15,7 @@ public class FeatureFlag
     public DateTime UpdatedAt { get; private set; } = DateTime.UtcNow;
     public DateTime? ArchivedAt { get; private set; }
 
-    public FeatureFlag(
+    public Flag(
         string name,
         EnvironmentType environment,
         bool isEnabled,
@@ -34,7 +34,7 @@ public class FeatureFlag
     }
 
     // Required by EF Core
-    private FeatureFlag()
+    private Flag()
     {
         Name = string.Empty;
         StrategyConfig = "{}";

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ FeatureFlag.Infrastructure  → EF Core, repository implementations, external co
 
 ## Domain Model
 
-- `FeatureFlag` – Core entity representing a feature with metadata, strategy, and environment.
+- `Flag` – Core entity representing a feature with metadata, strategy, and environment.
 - `RolloutStrategy` – Enum representing strategy types (None, Percentage, RoleBased).
 - `EnvironmentType` – Enum for Development, Staging, Production.
 - `FeatureEvaluationContext` – Context containing user and environment info for evaluation.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -102,7 +102,7 @@ The system follows a **layered architecture with strong separation of concerns**
 
 **Core Entities:**
 
-* `FeatureFlag`
+* `Flag`
 * `FeatureEvaluationContext`
 
 **Enums:**

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -12,7 +12,7 @@ The domain layer and project structure are in place. The remaining Phase 0 work 
 
 ### Domain Layer
 
-* `FeatureFlag` entity with controlled mutation (private setters, explicit update methods)
+* `Flag` entity with controlled mutation (private setters, explicit update methods)
 * `FeatureEvaluationContext` value object
 * `RolloutStrategy` enum (None, Percentage, RoleBased)
 * `EnvironmentType` enum (Development, Staging, Production)


### PR DESCRIPTION
Renames the FeatureFlag domain entity to Flag to resolve a naming collision 
between the entity and its containing namespace (FeatureFlag.Domain.Entities).

- Renamed FeatureFlag.cs to Flag.cs
- Renamed class from FeatureFlag to Flag
- Updated all internal references
- Updated architecture.md, current-state.md, and README.md to reflect the change