### PR TITLE
feature: add IFeatureFlagService and IRolloutStrategy interfaces

### DIFF
--- a/FeatureFlag.Application/Interfaces/IFeatureFlagService.cs
+++ b/FeatureFlag.Application/Interfaces/IFeatureFlagService.cs
@@ -1,0 +1,11 @@
+using FeatureFlag.Domain.Entities;
+using FeatureFlag.Domain.Enums;
+using FeatureFlag.Domain.ValueObjects;
+
+namespace FeatureFlag.Application.Interfaces;
+
+public interface IFeatureFlagService
+{
+    Flag GetFlag(string name, EnvironmentType environment);
+    bool IsEnabled(string flagName, FeatureEvaluationContext context);
+}

--- a/FeatureFlag.Domain/Interfaces/IRolloutStrategy.cs
+++ b/FeatureFlag.Domain/Interfaces/IRolloutStrategy.cs
@@ -1,0 +1,9 @@
+using FeatureFlag.Domain.Entities;
+using FeatureFlag.Domain.ValueObjects;
+
+namespace FeatureFlag.Domain.Interfaces;
+
+public interface IRolloutStrategy
+{
+    bool Evaluate(Flag flag, FeatureEvaluationContext context);
+}


### PR DESCRIPTION
Adds the two core interfaces that define the service and strategy contracts:

- Add IRolloutStrategy to FeatureFlag.Domain — single Evaluate method accepting a Flag and FeatureEvaluationContext
- Add IFeatureFlagService to FeatureFlag.Application — GetFlag for retrieval, IsEnabled for evaluation orchestration
- Interfaces establish layer boundaries before any implementations are written