### PR TITLE
feat: implement evaluation engine, strategies, and service wiring

### DIFF
--- a/FeatureFlag.Api/Program.cs
+++ b/FeatureFlag.Api/Program.cs
@@ -1,3 +1,6 @@
+using FeatureFlag.Application;
+using FeatureFlag.Infrastructure;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Core framework services
@@ -6,8 +9,8 @@ builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddOpenApi();
 
 // Application + Infrastructure registrations
-// builder.Services.AddApplication();
-// builder.Services.AddInfrastructure(builder.Configuration);
+builder.Services.AddApplication();
+builder.Services.AddInfrastructure(builder.Configuration);
 
 var app = builder.Build();
 

--- a/FeatureFlag.Application/DependencyInjection.cs
+++ b/FeatureFlag.Application/DependencyInjection.cs
@@ -1,0 +1,27 @@
+using FeatureFlag.Application.Evaluation;
+using FeatureFlag.Application.Interfaces;
+using FeatureFlag.Application.Services;
+using FeatureFlag.Application.Strategies;
+using FeatureFlag.Domain.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FeatureFlag.Application;
+
+public static class DependencyInjection
+{
+    public static IServiceCollection AddApplication(this IServiceCollection services)
+    {
+        // Strategies — Singleton: stateless, safe to share across requests
+        services.AddSingleton<IRolloutStrategy, NoneStrategy>();
+        services.AddSingleton<IRolloutStrategy, PercentageStrategy>();
+        services.AddSingleton<IRolloutStrategy, RoleStrategy>();
+
+        // Evaluator — Singleton: depends only on Singleton strategies
+        services.AddSingleton<FeatureEvaluator>();
+
+        // Service — Scoped: depends on Scoped repository
+        services.AddScoped<IFeatureFlagService, FeatureFlagService>();
+
+        return services;
+    }
+}

--- a/FeatureFlag.Application/Evaluation/FeatureEvaluator.cs
+++ b/FeatureFlag.Application/Evaluation/FeatureEvaluator.cs
@@ -1,0 +1,39 @@
+using FeatureFlag.Domain.Entities;
+using FeatureFlag.Domain.Enums;
+using FeatureFlag.Domain.Interfaces;
+using FeatureFlag.Domain.ValueObjects;
+
+namespace FeatureFlag.Application.Evaluation;
+
+public sealed class FeatureEvaluator
+{
+    private readonly Dictionary<RolloutStrategy, IRolloutStrategy> _strategies;
+
+    public FeatureEvaluator(IEnumerable<IRolloutStrategy> strategies)
+    {
+        _strategies = strategies.ToDictionary(s => s.StrategyType);
+    }
+
+    /// <summary>
+    /// Evaluates whether the given flag is enabled for the provided context.
+    /// </summary>
+    /// <remarks>
+    /// PRECONDITION: Callers are responsible for checking <see cref="Flag.IsEnabled"/>
+    /// before calling this method. The evaluator assumes the flag is active and will
+    /// dispatch to the appropriate strategy regardless of enabled state.
+    ///
+    /// This contract is intentionally not enforced here via a guard clause — the
+    /// evaluator is a pure strategy dispatcher, not a policy enforcer. Policy lives
+    /// at the service boundary (<see cref="FeatureFlagService"/>).
+    ///
+    /// If this method is called from any context other than FeatureFlagService,
+    /// revisit whether the IsEnabled check needs to be added back here.
+    /// </remarks>
+    public bool Evaluate(Flag flag, FeatureEvaluationContext context)
+    {
+        if (!_strategies.TryGetValue(flag.StrategyType, out var strategy))
+            return false;
+
+        return strategy.Evaluate(flag, context);
+    }
+}

--- a/FeatureFlag.Application/FeatureFlag.Application.csproj
+++ b/FeatureFlag.Application/FeatureFlag.Application.csproj
@@ -4,6 +4,10 @@
     <ProjectReference Include="..\FeatureFlag.Domain\FeatureFlag.Domain.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
+  </ItemGroup>
+
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/FeatureFlag.Application/Services/FeatureFlagService.cs
+++ b/FeatureFlag.Application/Services/FeatureFlagService.cs
@@ -1,0 +1,36 @@
+using FeatureFlag.Application.Evaluation;
+using FeatureFlag.Application.Interfaces;
+using FeatureFlag.Domain.Entities;
+using FeatureFlag.Domain.Enums;
+using FeatureFlag.Domain.Interfaces;
+using FeatureFlag.Domain.ValueObjects;
+
+namespace FeatureFlag.Application.Services;
+
+public sealed class FeatureFlagService : IFeatureFlagService
+{
+    private readonly IFeatureFlagRepository _repository;
+    private readonly FeatureEvaluator _evaluator;
+
+    public FeatureFlagService(IFeatureFlagRepository repository, FeatureEvaluator evaluator)
+    {
+        _repository = repository;
+        _evaluator = evaluator;
+    }
+
+    public Flag GetFlag(string name, EnvironmentType environment)
+    {
+        return _repository.GetByName(name, environment)
+            ?? throw new KeyNotFoundException($"Flag '{name}' not found in {environment}.");
+    }
+
+    public bool IsEnabled(string flagName, FeatureEvaluationContext context)
+    {
+        var flag = _repository.GetByName(flagName, context.Environment);
+
+        if (flag is null || !flag.IsEnabled)
+            return false;
+
+        return _evaluator.Evaluate(flag, context);
+    }
+}

--- a/FeatureFlag.Application/Strategies/NoneStrategy.cs
+++ b/FeatureFlag.Application/Strategies/NoneStrategy.cs
@@ -1,0 +1,13 @@
+using FeatureFlag.Domain.Entities;
+using FeatureFlag.Domain.Enums;
+using FeatureFlag.Domain.Interfaces;
+using FeatureFlag.Domain.ValueObjects;
+
+namespace FeatureFlag.Application.Strategies;
+
+public sealed class NoneStrategy : IRolloutStrategy
+{
+    public RolloutStrategy StrategyType => RolloutStrategy.None;
+
+    public bool Evaluate(Flag flag, FeatureEvaluationContext context) => true;
+}

--- a/FeatureFlag.Application/Strategies/PercentageStrategy.cs
+++ b/FeatureFlag.Application/Strategies/PercentageStrategy.cs
@@ -1,0 +1,30 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using FeatureFlag.Domain.Entities;
+using FeatureFlag.Domain.Enums;
+using FeatureFlag.Domain.Interfaces;
+using FeatureFlag.Domain.ValueObjects;
+
+namespace FeatureFlag.Application.Strategies;
+
+public sealed class PercentageStrategy : IRolloutStrategy
+{
+    public RolloutStrategy StrategyType => RolloutStrategy.Percentage;
+
+    public bool Evaluate(Flag flag, FeatureEvaluationContext context)
+    {
+        var config = JsonSerializer.Deserialize<PercentageConfig>(flag.StrategyConfig);
+
+        if (config is null || config.Percentage is < 0 or > 100)
+            return false;
+
+        var input = $"{context.UserId}:{flag.Name}";
+        var hashBytes = SHA256.HashData(Encoding.UTF8.GetBytes(input));
+        var bucket = BitConverter.ToUInt32(hashBytes, 0) % 100;
+
+        return bucket < (uint)config.Percentage;
+    }
+
+    private sealed record PercentageConfig(int Percentage);
+}

--- a/FeatureFlag.Application/Strategies/RoleStrategy.cs
+++ b/FeatureFlag.Application/Strategies/RoleStrategy.cs
@@ -1,0 +1,28 @@
+using System.Text.Json;
+using FeatureFlag.Domain.Entities;
+using FeatureFlag.Domain.Enums;
+using FeatureFlag.Domain.Interfaces;
+using FeatureFlag.Domain.ValueObjects;
+
+namespace FeatureFlag.Application.Strategies;
+
+public sealed class RoleStrategy : IRolloutStrategy
+{
+    public RolloutStrategy StrategyType => RolloutStrategy.RoleBased;
+
+    public bool Evaluate(Flag flag, FeatureEvaluationContext context)
+    {
+        var config = JsonSerializer.Deserialize<RoleConfig>(flag.StrategyConfig);
+
+        if (config is null || config.Roles is null || config.Roles.Count == 0)
+            return false;
+
+        var allowedRoles = new HashSet<string>(
+            config.Roles,
+            StringComparer.OrdinalIgnoreCase);
+
+        return context.UserRoles.Any(role => allowedRoles.Contains(role));
+    }
+
+    private sealed record RoleConfig(List<string> Roles);
+}

--- a/FeatureFlag.Domain/Interfaces/IFeatureFlagRepository.cs
+++ b/FeatureFlag.Domain/Interfaces/IFeatureFlagRepository.cs
@@ -1,0 +1,10 @@
+using FeatureFlag.Domain.Entities;
+using FeatureFlag.Domain.Enums;
+
+namespace FeatureFlag.Domain.Interfaces;
+
+public interface IFeatureFlagRepository
+{
+    Flag? GetByName(string name, EnvironmentType environment);
+    IReadOnlyList<Flag> GetAll(EnvironmentType environment);
+}

--- a/FeatureFlag.Domain/Interfaces/IRolloutStrategy.cs
+++ b/FeatureFlag.Domain/Interfaces/IRolloutStrategy.cs
@@ -1,9 +1,11 @@
 using FeatureFlag.Domain.Entities;
+using FeatureFlag.Domain.Enums;
 using FeatureFlag.Domain.ValueObjects;
 
 namespace FeatureFlag.Domain.Interfaces;
 
 public interface IRolloutStrategy
 {
+    RolloutStrategy StrategyType { get; }
     bool Evaluate(Flag flag, FeatureEvaluationContext context);
 }

--- a/FeatureFlag.Infrastructure/DependencyInjection.cs
+++ b/FeatureFlag.Infrastructure/DependencyInjection.cs
@@ -1,0 +1,17 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FeatureFlag.Infrastructure;
+
+public static class DependencyInjection
+{
+    public static IServiceCollection AddInfrastructure(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        // TODO: services.AddDbContext<FeatureFlagDbContext>(...)
+        // TODO: services.AddScoped<IFeatureFlagRepository, FeatureFlagRepository>()
+
+        return services;
+    }
+}

--- a/FeatureFlag.Infrastructure/FeatureFlag.Infrastructure.csproj
+++ b/FeatureFlag.Infrastructure/FeatureFlag.Infrastructure.csproj
@@ -5,6 +5,11 @@
     <ProjectReference Include="..\FeatureFlag.Domain\FeatureFlag.Domain.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
+  </ItemGroup>
+
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/claude.md
+++ b/claude.md
@@ -21,6 +21,14 @@ My goals:
 
 ---
 
+## About You
+
+You are a Senior-Level Software Engineer in the .Net Ecosystem. Your specialties are these: Prompt Engineering (you are always looking for ways to help the one you mentor to communicate with you better), API/System Design (something I'm most interested in), Docker, AI-Integration into dev workflows, Claude, and most importantly, C#/.Net. Your role is to help me write good clean code and understand what it is that I'm building. I want you to prepare me for interviews as we code. And I'm not afraid to deep-dive into some of the more stranger aspects of the language and framework. I want to understand .Net at a deep level.
+
+You will be given a spec document every time we work on this project which you will analyze. I'm using a different Claude instance to serve as my System Architect/Product Owner. You will implement. Always analyze the spec doc for implementation decisions. When finished, you will create <feature-branch-name>-implementation.md file which you will store in the /docs/decisions folder. Use evaluation-engine-implementation.md as an example.
+
+---
+
 ## How You Should Work With Me
 
 **Code quality:**
@@ -31,7 +39,7 @@ My goals:
 
 **Mentorship:**
 - You are my senior engineering partner, not just a code generator
-- Explain the *why* behind decisions briefly but clearly — assume I'm a junior to mid-level engieer.
+- Explain the *why* behind decisions briefly but clearly — assume I'm a junior to mid-level engineer.
 - Challenge weak design decisions and propose better alternatives with reasoning
 - When relevant, suggest improvements that strengthen the project professionally: testing, logging, observability, CI/CD, cloud readiness
 
@@ -59,4 +67,6 @@ My goals:
 
 ## Before You Proceed
 
-If a request is ambiguous or underspecified, ask clarifying questions before writing code or making architectural decisions.
+- If a request is ambiguous or underspecified, ask clarifying questions before writing code or making architectural decisions.
+- When provided with the Requirements List for the new feature, refactor, or debug session, review those requirements and ask clarify questions. 
+- I would also like to use this opportunity to learn to communicate with you better (Prompt Engineering)

--- a/docs/current-state.md
+++ b/docs/current-state.md
@@ -4,7 +4,8 @@
 
 The project is currently in **Phase 0 — Foundation (In Progress)**.
 
-The domain layer and project structure are in place. The remaining Phase 0 work — interfaces, evaluation engine, strategies, persistence, and controllers — has not yet been implemented.
+The evaluation engine is implemented and the solution builds clean. The remaining Phase 0
+work is persistence (EF Core + repository) and the API layer (controllers, Swagger).
 
 ---
 
@@ -12,95 +13,139 @@ The domain layer and project structure are in place. The remaining Phase 0 work 
 
 ### Domain Layer
 
-* `Flag` entity with controlled mutation (private setters, explicit update methods)
-* `FeatureEvaluationContext` value object
-* `RolloutStrategy` enum (None, Percentage, RoleBased)
-* `EnvironmentType` enum (Development, Staging, Production)
+- `Flag` entity with controlled mutation (private setters, explicit update methods)
+- `FeatureEvaluationContext` value object — `IEquatable<T>` implemented, guard clauses, immutable roles
+- `RolloutStrategy` enum (None, Percentage, RoleBased)
+- `EnvironmentType` enum (None = 0 sentinel, Development, Staging, Production)
+- `IRolloutStrategy` interface — includes `StrategyType` property for registry dispatch
+- `IFeatureFlagRepository` interface
+
+### Application Layer
+
+- `NoneStrategy` — passthrough, always returns true
+- `PercentageStrategy` — deterministic SHA256 hashing into buckets
+- `RoleStrategy` — config-driven, case-insensitive, fail-closed role matching
+- `FeatureEvaluator` — registry dispatch pattern, dictionary keyed by `RolloutStrategy`
+- `FeatureFlagService` — orchestrates repository + evaluator, implements `IFeatureFlagService`
+- `DependencyInjection.cs` — `AddApplication()` extension method
+
+### Infrastructure Layer
+
+- `DependencyInjection.cs` stub — `AddInfrastructure()` wired in `Program.cs`, `TODO` comments in place
+
+### API Layer
+
+- `Program.cs` — `AddApplication()` and `AddInfrastructure()` wired up
+- `AddOpenApi()` present from scaffold
 
 ### Project Structure
 
-* Clean Architecture solution with four dedicated projects:
+- Clean Architecture solution: Domain, Application, Infrastructure, Api, Tests
+- Dependency rule enforced: Domain has no outward dependencies
+- DevContainer configured with .NET 9 image (see Known Issues)
+- `docs/decisions/` folder established for Architecture Decision Records
 
-  * `FeatureFlag.Domain` — entities, enums, value objects
-  * `FeatureFlag.Application` — project scaffolded, not yet populated
-  * `FeatureFlag.Infrastructure` — project scaffolded, not yet populated
-  * `FeatureFlag.Api` — project scaffolded, minimal bootstrap only
-* `FeatureFlag.Tests` — project scaffolded, no tests written yet
-* Dependency rule enforced: Domain has no outward dependencies
-* DevContainer configured with .NET 9, Claude Code, GitHub CLI, and VS Code extensions
+### Tests
+
+- `FeatureEvaluationContextTests` — covers constructor guards, equality, hash code
 
 ---
 
 ## ❌ What Is Not Yet Built (Remaining Phase 0)
 
-### Application Layer
-
-* `IFeatureFlagService` interface
-* `FeatureEvaluator` — evaluation engine
-* Use cases and DTOs
-
-### Strategy Layer
-
-* `IRolloutStrategy` interface
-* `PercentageStrategy` implementation
-* `RoleStrategy` implementation
-
 ### Infrastructure Layer
 
-* EF Core setup and DbContext
-* Entity configuration and enum mapping
-* Repository pattern implementation
+- EF Core `DbContext` and entity configuration
+- `FeatureFlagRepository` — concrete implementation of `IFeatureFlagRepository`
+- Repository registered in `AddInfrastructure()` (currently `TODO` stubs)
 
 ### API Layer
 
-* Feature flag controllers
-* Swagger/OpenAPI configuration
-* Dependency injection wiring (`AddApplication`, `AddInfrastructure`)
+- Feature flag controllers (CRUD + evaluation endpoint)
+- Swagger/OpenAPI examples and configuration
 
 ---
 
 ## ⚠️ Known Issues
 
-### FeatureEvaluationContext
+### KI-001 — DevContainer Image Does Not Have a .NET 10 Tag
 
-* Missing `IEquatable<T>` implementation — two contexts with identical values are not considered equal
-* `EnvironmentType` has no guard against invalid enum values
-* Inline namespace qualifier (`Enums.EnvironmentType`) should be replaced with a proper `using` statement
+**Severity:** Medium — build works today, but version drift will become a problem  
+**Status:** Deferred — tracked for resolution before Phase 1 begins
 
-### EnvironmentType Enum
+The devcontainer currently uses:
+```jsonc
+"image": "mcr.microsoft.com/devcontainers/dotnet:9.0"
+```
 
-* Default value is `Development` (implicit zero) — a misconfigured context silently evaluates as Development
-* Consider adding `None = 0` as an explicit invalid sentinel
+No `devcontainers/dotnet:10.0` tag exists. The active SDK inside the container
+is `10.0.201`, which means newly added packages resolve to `10.0.x` versions
+while the solution targets `net9.0`.
 
-### roadmap.md (now resolved)
+**Planned fix:** Replace the `image` property with a custom `Dockerfile` based on
+`mcr.microsoft.com/dotnet/sdk:10.0` and upgrade all `.csproj` files to `net10.0`.
+This work is scoped to a `refactor/upgrade-net10` branch before Phase 1 begins.
 
-* Previously marked Phase 0 items as complete that were not yet implemented — corrected in this update
+---
+
+### KI-002 — `FeatureEvaluator.Evaluate` Has an Implicit Precondition
+
+**Severity:** Low — no bug today, potential footgun if the evaluator gains new callers  
+**Status:** Documented — tracked for review when new callers are introduced
+
+The original spec placed an `IsEnabled` short-circuit inside `FeatureEvaluator.Evaluate`.
+During implementation, Claude Code removed it because `FeatureFlagService.IsEnabled`
+already performs the same check before calling the evaluator.
+
+The evaluator is now a pure strategy dispatcher. The precondition — that callers must
+check `Flag.IsEnabled` before calling `Evaluate` — is documented via XML doc comment
+on the method but is not enforced by a guard clause.
+
+**Action required if:** A second caller of `FeatureEvaluator` is introduced anywhere
+in the codebase. At that point, re-evaluate whether the guard clause should be restored
+inside the evaluator, or whether the precondition is explicit enough in the new call site.
+
+---
+
+### KI-003 — `StrategyConfig` Validation Is Deferred to Runtime
+
+**Severity:** Medium — misconfiguration fails silently at evaluation time  
+**Status:** Deferred — scheduled for Phase 1 (CRUD endpoint design)
+
+Both `PercentageStrategy` and `RoleStrategy` deserialize `Flag.StrategyConfig` at
+evaluation time and fail closed on bad config. There is no validation at flag creation time.
+
+A flag created with a malformed `StrategyConfig` will silently return `false` for every
+user until someone investigates.
+
+**Planned fix:** Add config validation at write time when the CRUD endpoints are built in
+Phase 1. A `FluentValidation` validator on the request DTO is the appropriate location.
+This should be treated as a Phase 1 requirement, not a nice-to-have.
 
 ---
 
 ## 🎯 Current Focus
 
-Complete the remaining Phase 0 work before moving into Phase 1.
+Complete the remaining Phase 0 work.
 
 ### Immediate Next Tasks
 
-1. Fix `FeatureEvaluationContext` — add `IEquatable`, guard clauses, clean up namespace
-2. Update `EnvironmentType` to add `None = 0`
-3. Define `IFeatureFlagService` and `IRolloutStrategy` interfaces
-4. Implement `FeatureEvaluator`
-5. Implement `PercentageStrategy` (deterministic hashing) and `RoleStrategy`
-6. Set up EF Core, DbContext, and repository
-7. Wire up controllers and Swagger in `Program.cs`
+1. `refactor/upgrade-net10` — swap devcontainer to custom Dockerfile, upgrade all projects to `net10.0`
+2. Implement EF Core `DbContext` and entity configuration
+3. Implement `FeatureFlagRepository`
+4. Wire up repository in `AddInfrastructure()`
+5. Create feature flag controllers
+6. Configure Swagger/OpenAPI
 
 ---
 
 ## 🧭 What Not To Do Right Now
 
-* No UI work
-* No authentication or authorization yet
-* No advanced rollout strategies
-* No observability pipeline
-* No performance optimization
+- No authentication or authorization yet
+- No advanced rollout strategies
+- No observability pipeline
+- No performance optimization
+- No UI work
 
 Focus strictly on **finishing Phase 0**.
 
@@ -110,19 +155,20 @@ Focus strictly on **finishing Phase 0**.
 
 Phase 0 is complete when:
 
-* All interfaces are defined
-* `FeatureEvaluator` dispatches to the correct strategy
-* Both strategies are implemented and return deterministic results
-* EF Core and repository are functional
-* Controllers are wired up and returning responses
-* Swagger is configured
+- All interfaces are defined ✅
+- `FeatureEvaluator` dispatches to the correct strategy ✅
+- Both strategies are implemented and return deterministic results ✅
+- EF Core and repository are functional
+- Controllers are wired up and returning responses
+- Swagger is configured
 
 ---
 
 ## 🧩 Notes for AI Assistants
 
-* The system is not production-ready
-* Prioritize correctness over feature expansion
-* Follow Clean Architecture — dependencies point inward toward Domain
-* Work within the established layer boundaries (Api → Application → Domain ← Infrastructure)
-* All evaluation logic must remain deterministic and isolated from persistence
+- The system is not production-ready
+- Prioritize correctness over feature expansion
+- Follow Clean Architecture — dependencies point inward toward Domain
+- Work within the established layer boundaries (Api → Application → Domain ← Infrastructure)
+- All evaluation logic must remain deterministic and isolated from persistence
+- See Known Issues above before modifying `FeatureEvaluator` or adding new callers

--- a/docs/decisions/evaluation-engine-implementation-notes.md
+++ b/docs/decisions/evaluation-engine-implementation-notes.md
@@ -1,0 +1,196 @@
+# Evaluation Engine — Implementation Notes
+ 
+**Session date:** 2026-03-24  
+**Branch:** `feature/evaluation-engine`  
+**Spec reference:** `docs/decisions/evaluation-engine.md`  
+**Build status:** Passed — 0 warnings, 0 errors
+ 
+---
+ 
+## 1. What Was Implemented
+ 
+All items in scope per the spec were completed:
+ 
+| File | Status |
+|---|---|
+| `Domain/Interfaces/IRolloutStrategy.cs` | Updated — `StrategyType` property added |
+| `Domain/Interfaces/IFeatureFlagRepository.cs` | Created |
+| `Application/Strategies/NoneStrategy.cs` | Created |
+| `Application/Strategies/PercentageStrategy.cs` | Created |
+| `Application/Strategies/RoleStrategy.cs` | Created |
+| `Application/Evaluation/FeatureEvaluator.cs` | Created |
+| `Application/Services/FeatureFlagService.cs` | Created |
+| `Application/DependencyInjection.cs` | Created |
+| `Infrastructure/DependencyInjection.cs` | Created (stub) |
+| `Api/Program.cs` | Updated — wired up `AddApplication()` and `AddInfrastructure()` |
+ 
+---
+ 
+## 2. Deviations from the Spec
+ 
+### 2.1 NuGet Packages Not Listed in the Spec
+ 
+The spec did not mention that any NuGet packages would need to be added. Two were required
+and added after user confirmation:
+ 
+| Package | Version | Project | Reason |
+|---|---|---|---|
+| `Microsoft.Extensions.DependencyInjection.Abstractions` | 10.0.5 | Application | Required for `IServiceCollection` in `DependencyInjection.cs` |
+| `Microsoft.Extensions.DependencyInjection.Abstractions` | 10.0.5 | Infrastructure | Required for `IServiceCollection` in `DependencyInjection.cs` |
+| `Microsoft.Extensions.Configuration.Abstractions` | 10.0.5 | Infrastructure | Required for `IConfiguration` in `DependencyInjection.cs` |
+ 
+**Architect note:** Using the `Abstractions`-only packages is intentional and correct.
+The Application and Infrastructure layers should depend only on contracts — not on the full
+DI implementation. The concrete implementation is provided transitively by the API project's
+`Microsoft.AspNetCore` SDK. This keeps the dependency direction clean.
+ 
+**Risk flag:** The solution targets `net9.0` but the SDK in the dev container is `10.0.201`,
+which resolved these packages to version `10.0.5`. The packages are backwards compatible and
+the build is clean, but this mismatch is tracked as **KI-001** in `docs/current-state.md`
+and must be resolved before Phase 1 begins.
+ 
+---
+ 
+### 2.2 `using` Directives Not Specified for `Program.cs`
+ 
+The spec instructed uncommenting the two wiring lines in `Program.cs` but did not include
+the required `using` directives. The following were added:
+ 
+```csharp
+using FeatureFlag.Application;
+using FeatureFlag.Infrastructure;
+```
+ 
+Without these, the extension methods `AddApplication()` and `AddInfrastructure()` are not
+visible to the top-level statement file, even though the project references were already
+in place. Minor spec gap — no architectural impact.
+ 
+---
+ 
+### 2.3 `IsEnabled` Check Consolidated to Service Layer
+ 
+The spec placed an `IsEnabled` short-circuit in `FeatureEvaluator.Evaluate`, but
+`FeatureFlagService.IsEnabled` already checks the same property before calling the evaluator.
+The check was removed from the evaluator.
+ 
+`FeatureEvaluator` is now a pure strategy dispatcher — given a flag, select the strategy
+and return the result. Policy decisions (is this flag on or off?) live at the service
+boundary, not inside the evaluation engine.
+ 
+**Architect note:** This is a defensible design call for the current codebase, where
+`FeatureEvaluator` has exactly one caller. However, if a second caller is introduced,
+the missing guard becomes a silent footgun. This deviation is tracked as **KI-002**
+in `docs/current-state.md`. A precondition comment has been added to
+`FeatureEvaluator.Evaluate` to document the contract explicitly.
+ 
+The comment reads:
+ 
+```csharp
+/// <summary>
+/// Evaluates whether the given flag is enabled for the provided context.
+/// </summary>
+/// <remarks>
+/// PRECONDITION: Callers are responsible for checking <see cref="Flag.IsEnabled"/>
+/// before calling this method. The evaluator assumes the flag is active and will
+/// dispatch to the appropriate strategy regardless of enabled state.
+///
+/// This contract is intentionally not enforced here via a guard clause — the
+/// evaluator is a pure strategy dispatcher, not a policy enforcer. Policy lives
+/// at the service boundary (<see cref="FeatureFlagService"/>).
+///
+/// If this method is called from any context other than FeatureFlagService,
+/// revisit whether the IsEnabled check needs to be added back here.
+/// </remarks>
+public bool Evaluate(Flag flag, FeatureEvaluationContext context)
+```
+ 
+---
+ 
+## 3. What Is Intentionally Out of Scope (This Session)
+ 
+Per the spec, the following were not implemented and remain as stubs or placeholders:
+ 
+- **EF Core / `DbContext`** — `Infrastructure/DependencyInjection.cs` contains `TODO` comments
+  for `AddDbContext` and `AddScoped<IFeatureFlagRepository>`. The real repository does not
+  exist yet.
+- **`IFeatureFlagRepository` implementation** — The interface is defined in Domain; no concrete
+  class exists. Any attempt to call `IFeatureFlagService` at runtime will fail with an unresolved
+  dependency error until this is implemented.
+- **Controllers** — No API endpoints exist. The service layer is fully wired but unreachable
+  from HTTP.
+- **Swagger/OpenAPI** — The `AddOpenApi()` call exists in `Program.cs` from the original
+  scaffold but no endpoint documentation has been configured.
+ 
+---
+ 
+## 4. Items Requiring Attention Before Merging to Main
+ 
+### 4.1 .NET Target Framework Version — KI-001
+ 
+All five projects currently target `net9.0`. The active SDK is `10.0.201`. The newly added
+packages resolved to version `10.0.5` (a .NET 10 release).
+ 
+The `mcr.microsoft.com/devcontainers/dotnet:10.0` image tag does not yet exist. The fix
+requires replacing the `image` property in `devcontainer.json` with a custom `Dockerfile`
+based on `mcr.microsoft.com/dotnet/sdk:10.0`, then upgrading all `.csproj` files to
+`net10.0`.
+ 
+This work is scoped to a dedicated `refactor/upgrade-net10` branch and should be completed
+before Phase 1 begins. Tracked as **KI-001** in `docs/current-state.md`.
+ 
+---
+ 
+### 4.2 `IsEnabled` Check Consolidated to Service Layer — KI-002
+ 
+Covered in section 2.3 above. Tracked as **KI-002** in `docs/current-state.md`.
+ 
+No immediate action required. Monitor when new callers of `FeatureEvaluator` are introduced.
+ 
+---
+ 
+### 4.3 `StrategyConfig` Validation Deferred to Runtime — KI-003
+ 
+Both `PercentageStrategy` and `RoleStrategy` deserialize `Flag.StrategyConfig` at evaluation
+time and fail closed on bad config. There is no validation at flag creation time. A flag with
+a malformed `StrategyConfig` will silently evaluate to `false` for every user until someone
+investigates.
+ 
+**Planned fix:** Add config validation at write time (when a flag is created or updated) as
+part of the Phase 1 CRUD endpoint work. A `FluentValidation` or custom validator on the
+request DTO is the appropriate location. This is a Phase 1 requirement, not a nice-to-have.
+ 
+Tracked as **KI-003** in `docs/current-state.md`.
+ 
+---
+ 
+## 5. Architecture Decisions Validated This Session
+ 
+The following decisions from the spec were implemented as written and held up without issues:
+ 
+- **Registry dispatch pattern** — `FeatureEvaluator` builds a `Dictionary<RolloutStrategy,
+  IRolloutStrategy>` at construction time. No switch statements. Adding a new strategy
+  requires only a new class and one DI registration line.
+- **DI lifetime separation** — Strategies and `FeatureEvaluator` are Singleton;
+  `FeatureFlagService` is Scoped. This matches the dependency chain and avoids the
+  captive dependency bug with EF Core `DbContext`.
+- **`IFeatureFlagRepository` in Domain** — Infrastructure implements it; Domain defines it;
+  Application consumes it. Dependency Inversion Principle is intact.
+- **Fail-closed behavior** — All strategies return `false` on null config, malformed JSON,
+  or missing strategy registration. No exceptions are thrown from the evaluation path.
+- **`Abstractions`-only NuGet packages** — Application and Infrastructure reference contracts
+  only, not the full DI implementation. Dependency direction is clean.
+ 
+---
+ 
+## 6. Next Session Scope (Phase 0 Completion)
+ 
+1. `refactor/upgrade-net10` — custom Dockerfile, upgrade all projects to `net10.0` **(do first)**
+2. Implement EF Core `DbContext` and entity configuration
+3. Implement `FeatureFlagRepository`
+4. Register repository in `Infrastructure/DependencyInjection.cs`
+5. Create feature flag controllers
+6. Configure Swagger/OpenAPI with meaningful examples
+ 
+---
+ 
+*FeatureFlagService | feature/evaluation-engine | Phase 0*

--- a/docs/decisions/evaluation-engine.md
+++ b/docs/decisions/evaluation-engine.md
@@ -1,0 +1,531 @@
+# Evaluation Engine — Implementation Spec
+
+**Branch:** `feature/evaluation-engine`  
+**Phase:** 0 — Foundation  
+**Status:** Ready for implementation
+
+---
+
+## 1. Purpose of This Document
+
+This is the implementation spec for the FeatureFlagService evaluation engine. It is intended to be read by Claude Code at the start of the implementation session before any code is written.
+
+It covers every class, interface, design decision, and wiring detail needed to implement the evaluation layer from scratch — without ambiguity.
+
+> **SCOPE**  
+> This spec covers: `FeatureEvaluator`, `PercentageStrategy`, `RoleStrategy`, `NoneStrategy`, `DependencyInjection` extension methods, and the `FeatureFlagService` orchestration class.  
+> It does **not** cover EF Core setup, controllers, or Swagger — those are separate sessions.
+
+---
+
+## 2. Architecture Context
+
+Before writing any code, understand the dependency rules that govern this project. Violating these breaks the Clean Architecture boundary.
+
+| Layer | Responsibility |
+|---|---|
+| `FeatureFlag.Domain` | Entities, enums, value objects, interfaces. Zero outward dependencies. |
+| `FeatureFlag.Application` | Use cases, service interfaces, evaluator, strategies. Depends on Domain only. |
+| `FeatureFlag.Infrastructure` | EF Core, repositories. Depends on Domain + Application. |
+| `FeatureFlag.Api` | Controllers, Program.cs, DI wiring. Depends on Application + Infrastructure. |
+| `FeatureFlag.Tests` | Unit tests. Depends on Domain + Application. |
+
+> **RULE**  
+> `IRolloutStrategy` lives in **Domain**. `FeatureEvaluator`, `PercentageStrategy`, `RoleStrategy`, `NoneStrategy`, and `IFeatureFlagService` live in **Application**. `DependencyInjection` extension methods live in Application and Infrastructure respectively. Do not move any of these.
+
+---
+
+## 3. Interfaces — Already Defined
+
+The following interfaces are already committed to the repo. Do **NOT** redefine or modify them. All new code must implement or consume them as-is.
+
+### 3.1 IRolloutStrategy (Domain)
+
+**Location:** `FeatureFlag.Domain/Interfaces/IRolloutStrategy.cs`
+
+```csharp
+namespace FeatureFlag.Domain.Interfaces;
+
+public interface IRolloutStrategy
+{
+    RolloutStrategy StrategyType { get; }
+    bool Evaluate(Flag flag, FeatureEvaluationContext context);
+}
+```
+
+> **NOTE**  
+> `StrategyType` is a property on the interface — not in the original stub. **Add it.**  
+> It is required so `FeatureEvaluator` can build a dictionary keyed by `RolloutStrategy` enum value. Without it, the registry dispatch pattern cannot work.
+
+---
+
+### 3.2 IFeatureFlagService (Application)
+
+**Location:** `FeatureFlag.Application/Interfaces/IFeatureFlagService.cs`
+
+```csharp
+namespace FeatureFlag.Application.Interfaces;
+
+public interface IFeatureFlagService
+{
+    Flag GetFlag(string name, EnvironmentType environment);
+    bool IsEnabled(string flagName, FeatureEvaluationContext context);
+}
+```
+
+---
+
+### 3.3 IFeatureFlagRepository (Domain) — CREATE THIS FILE
+
+**Location:** `FeatureFlag.Domain/Interfaces/IFeatureFlagRepository.cs`
+
+This interface belongs in Domain so Infrastructure can implement it without creating an illegal dependency. This is the standard Clean Architecture repository pattern.
+
+```csharp
+namespace FeatureFlag.Domain.Interfaces;
+
+public interface IFeatureFlagRepository
+{
+    Flag? GetByName(string name, EnvironmentType environment);
+    IReadOnlyList<Flag> GetAll(EnvironmentType environment);
+}
+```
+
+---
+
+## 4. Classes to Implement
+
+### 4.1 PercentageStrategy
+
+| Property | Value |
+|---|---|
+| File location | `FeatureFlag.Application/Strategies/PercentageStrategy.cs` |
+| Implements | `IRolloutStrategy` |
+| `StrategyType` property | `RolloutStrategy.Percentage` |
+| Purpose | Deterministically assign users to a rollout percentage using SHA256 hashing |
+
+**Config shape (JSON stored in `Flag.StrategyConfig`):**
+
+```json
+{ "percentage": 30 }
+```
+
+**Algorithm — step by step:**
+
+1. Deserialize `Flag.StrategyConfig` into a `PercentageConfig` record.
+2. If config is null or `Percentage` is outside 0–100, return `false` (fail closed).
+3. Build input string: `$"{context.UserId}:{flag.Name}"`
+4. Hash that string using `SHA256.HashData(Encoding.UTF8.GetBytes(input))`.
+5. Convert first 4 bytes to `uint` via `BitConverter.ToUInt32(hashBytes, 0)`.
+6. Compute `bucket = hashValue % 100`.
+7. Return `bucket < (uint)config.Percentage`.
+
+> **WHY `uint` and not `int`**  
+> `BitConverter.ToUInt32` returns an unsigned 32-bit integer. Use `uint` throughout the comparison. A signed `int` can produce negative values after conversion, and a negative bucket number makes the less-than comparison silently incorrect. `uint` eliminates that class of bug entirely.
+
+> **WHY include `flag.Name` in the hash input**  
+> Hashing `UserId` alone means the same 30% of users are in every rollout. Including the flag name ensures each flag produces an independent user distribution. User A might be in bucket 12 for flag X but bucket 74 for flag Y.
+
+**`PercentageConfig` record:**
+
+Define as a private nested record inside `PercentageStrategy`. Keep it internal to the Application layer.
+
+```csharp
+private sealed record PercentageConfig(int Percentage);
+```
+
+**Full implementation:**
+
+```csharp
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using FeatureFlag.Domain.Entities;
+using FeatureFlag.Domain.Enums;
+using FeatureFlag.Domain.Interfaces;
+using FeatureFlag.Domain.ValueObjects;
+
+namespace FeatureFlag.Application.Strategies;
+
+public sealed class PercentageStrategy : IRolloutStrategy
+{
+    public RolloutStrategy StrategyType => RolloutStrategy.Percentage;
+
+    public bool Evaluate(Flag flag, FeatureEvaluationContext context)
+    {
+        var config = JsonSerializer.Deserialize<PercentageConfig>(flag.StrategyConfig);
+
+        if (config is null || config.Percentage is < 0 or > 100)
+            return false;
+
+        var input = $"{context.UserId}:{flag.Name}";
+        var hashBytes = SHA256.HashData(Encoding.UTF8.GetBytes(input));
+        var bucket = BitConverter.ToUInt32(hashBytes, 0) % 100;
+
+        return bucket < (uint)config.Percentage;
+    }
+
+    private sealed record PercentageConfig(int Percentage);
+}
+```
+
+---
+
+### 4.2 RoleStrategy
+
+| Property | Value |
+|---|---|
+| File location | `FeatureFlag.Application/Strategies/RoleStrategy.cs` |
+| Implements | `IRolloutStrategy` |
+| `StrategyType` property | `RolloutStrategy.RoleBased` |
+| Purpose | Grant access to users whose roles intersect with the configured allowed roles |
+
+**Config shape (JSON stored in `Flag.StrategyConfig`):**
+
+```json
+{ "roles": ["admin", "beta-tester"] }
+```
+
+**Algorithm — step by step:**
+
+1. Deserialize `Flag.StrategyConfig` into a `RoleConfig` record.
+2. If config is null or `config.Roles` is null or empty, return `false` (fail closed).
+3. Build a `HashSet<string>` from `config.Roles` using `StringComparer.OrdinalIgnoreCase`.
+4. Return `context.UserRoles.Any(role => allowedRoles.Contains(role))`.
+
+> **OR logic — not AND**  
+> The strategy uses OR logic: the user must have at least ONE of the configured roles. AND logic is rare in practice and usually signals that role granularity should be improved upstream. OR is the correct default for a feature flag system.
+
+> **WHY `HashSet` + `OrdinalIgnoreCase`**  
+> `HashSet` gives O(1) lookups vs O(n) for `List` — important when a user has many roles. `OrdinalIgnoreCase` handles mismatches like `"Admin"` vs `"admin"` that are common between identity providers and config files. Two separate bugs prevented by one line.
+
+**Full implementation:**
+
+```csharp
+using System.Text.Json;
+using FeatureFlag.Domain.Entities;
+using FeatureFlag.Domain.Enums;
+using FeatureFlag.Domain.Interfaces;
+using FeatureFlag.Domain.ValueObjects;
+
+namespace FeatureFlag.Application.Strategies;
+
+public sealed class RoleStrategy : IRolloutStrategy
+{
+    public RolloutStrategy StrategyType => RolloutStrategy.RoleBased;
+
+    public bool Evaluate(Flag flag, FeatureEvaluationContext context)
+    {
+        var config = JsonSerializer.Deserialize<RoleConfig>(flag.StrategyConfig);
+
+        if (config is null || config.Roles is null || config.Roles.Count == 0)
+            return false;
+
+        var allowedRoles = new HashSet<string>(
+            config.Roles,
+            StringComparer.OrdinalIgnoreCase);
+
+        return context.UserRoles.Any(role => allowedRoles.Contains(role));
+    }
+
+    private sealed record RoleConfig(List<string> Roles);
+}
+```
+
+---
+
+### 4.3 NoneStrategy (Passthrough)
+
+When `RolloutStrategy` is `None`, the flag is on for everyone. Rather than handling this as a special case inside `FeatureEvaluator` (which would be a conditional, not a strategy), implement a `NoneStrategy` that always returns `true`.
+
+| Property | Value |
+|---|---|
+| File location | `FeatureFlag.Application/Strategies/NoneStrategy.cs` |
+| Implements | `IRolloutStrategy` |
+| `StrategyType` property | `RolloutStrategy.None` |
+| Purpose | Passthrough — flag is on, no targeting rules apply |
+
+```csharp
+using FeatureFlag.Domain.Entities;
+using FeatureFlag.Domain.Interfaces;
+using FeatureFlag.Domain.ValueObjects;
+
+namespace FeatureFlag.Application.Strategies;
+
+public sealed class NoneStrategy : IRolloutStrategy
+{
+    public RolloutStrategy StrategyType => RolloutStrategy.None;
+
+    public bool Evaluate(Flag flag, FeatureEvaluationContext context) => true;
+}
+```
+
+> **DESIGN NOTE**  
+> `NoneStrategy` keeps `FeatureEvaluator` free of conditionals. Every `RolloutStrategy` value maps to a strategy class. The evaluator never needs to know about special cases — it just dispatches. This is the Open/Closed Principle in practice: add behavior by adding classes, not by modifying existing ones.
+
+---
+
+### 4.4 FeatureEvaluator
+
+| Property | Value |
+|---|---|
+| File location | `FeatureFlag.Application/Evaluation/FeatureEvaluator.cs` |
+| Purpose | Dispatch evaluation to the correct `IRolloutStrategy` based on `Flag.StrategyType` |
+| DI Lifetime | Singleton — stateless, safe to share across requests |
+| Dependencies | `IEnumerable<IRolloutStrategy>` — injected by DI container |
+
+**How registry dispatch works:**
+
+The constructor receives all registered `IRolloutStrategy` implementations via `IEnumerable<IRolloutStrategy>`. It builds a dictionary keyed by each strategy's `StrategyType` property. At evaluation time it looks up the correct strategy in O(1) and delegates.
+
+```csharp
+using FeatureFlag.Domain.Entities;
+using FeatureFlag.Domain.Enums;
+using FeatureFlag.Domain.Interfaces;
+using FeatureFlag.Domain.ValueObjects;
+
+namespace FeatureFlag.Application.Evaluation;
+
+public sealed class FeatureEvaluator
+{
+    private readonly Dictionary<RolloutStrategy, IRolloutStrategy> _strategies;
+
+    public FeatureEvaluator(IEnumerable<IRolloutStrategy> strategies)
+    {
+        _strategies = strategies.ToDictionary(s => s.StrategyType);
+    }
+
+    public bool Evaluate(Flag flag, FeatureEvaluationContext context)
+    {
+        if (!flag.IsEnabled)
+            return false;
+
+        if (!_strategies.TryGetValue(flag.StrategyType, out var strategy))
+            return false; // unknown strategy = fail closed
+
+        return strategy.Evaluate(flag, context);
+    }
+}
+```
+
+> **SHORT CIRCUIT**  
+> The check `if (!flag.IsEnabled) return false` must come before strategy dispatch. A disabled flag should never reach a strategy. This is intentional and must not be removed.
+
+> **UNKNOWN STRATEGY = FAIL CLOSED**  
+> If the dictionary does not contain the flag's `StrategyType` (e.g. a future enum value not yet implemented), the evaluator returns `false`. Do not throw an exception here — a missing strategy should disable the feature silently, not crash the request.
+
+---
+
+### 4.5 FeatureFlagService
+
+| Property | Value |
+|---|---|
+| File location | `FeatureFlag.Application/Services/FeatureFlagService.cs` |
+| Implements | `IFeatureFlagService` |
+| DI Lifetime | **Scoped** — depends on `IFeatureFlagRepository` which is Scoped |
+| Dependencies | `IFeatureFlagRepository`, `FeatureEvaluator` |
+| Purpose | Orchestrate: fetch flag from repository, pass to evaluator, return result |
+
+> **LIFETIME WARNING**  
+> `FeatureFlagService` must be **Scoped**, not Singleton. It depends on `IFeatureFlagRepository` which wraps EF Core `DbContext` — a Scoped service. If `FeatureFlagService` were Singleton, the repository would be captured inside it and never released. ASP.NET Core will throw an `InvalidOperationException` at startup if this is wrong.
+
+```csharp
+using FeatureFlag.Application.Evaluation;
+using FeatureFlag.Application.Interfaces;
+using FeatureFlag.Domain.Entities;
+using FeatureFlag.Domain.Enums;
+using FeatureFlag.Domain.Interfaces;
+using FeatureFlag.Domain.ValueObjects;
+
+namespace FeatureFlag.Application.Services;
+
+public sealed class FeatureFlagService : IFeatureFlagService
+{
+    private readonly IFeatureFlagRepository _repository;
+    private readonly FeatureEvaluator _evaluator;
+
+    public FeatureFlagService(
+        IFeatureFlagRepository repository,
+        FeatureEvaluator evaluator)
+    {
+        _repository = repository;
+        _evaluator = evaluator;
+    }
+
+    public Flag GetFlag(string name, EnvironmentType environment)
+    {
+        return _repository.GetByName(name, environment)
+            ?? throw new KeyNotFoundException($"Flag '{name}' not found in {environment}.");
+    }
+
+    public bool IsEnabled(string flagName, FeatureEvaluationContext context)
+    {
+        var flag = _repository.GetByName(flagName, context.Environment);
+
+        if (flag is null || !flag.IsEnabled)
+            return false;
+
+        return _evaluator.Evaluate(flag, context);
+    }
+}
+```
+
+---
+
+## 5. Dependency Injection Wiring
+
+Each layer owns its own DI registration. `Program.cs` calls the extension methods — it never references concrete types directly.
+
+### 5.1 Application Layer — DependencyInjection.cs
+
+**Location:** `FeatureFlag.Application/DependencyInjection.cs`
+
+```csharp
+using FeatureFlag.Application.Evaluation;
+using FeatureFlag.Application.Interfaces;
+using FeatureFlag.Application.Services;
+using FeatureFlag.Application.Strategies;
+using FeatureFlag.Domain.Interfaces;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FeatureFlag.Application;
+
+public static class DependencyInjection
+{
+    public static IServiceCollection AddApplication(this IServiceCollection services)
+    {
+        // Strategies — Singleton: stateless, safe to share across requests
+        services.AddSingleton<IRolloutStrategy, NoneStrategy>();
+        services.AddSingleton<IRolloutStrategy, PercentageStrategy>();
+        services.AddSingleton<IRolloutStrategy, RoleStrategy>();
+
+        // Evaluator — Singleton: depends only on Singleton strategies
+        services.AddSingleton<FeatureEvaluator>();
+
+        // Service — Scoped: depends on Scoped repository
+        services.AddScoped<IFeatureFlagService, FeatureFlagService>();
+
+        return services;
+    }
+}
+```
+
+---
+
+### 5.2 Infrastructure Layer — DependencyInjection.cs (stub)
+
+**Location:** `FeatureFlag.Infrastructure/DependencyInjection.cs`
+
+EF Core and `DbContext` are out of scope for this session. Create this stub so the solution compiles and the wiring pattern is in place.
+
+```csharp
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FeatureFlag.Infrastructure;
+
+public static class DependencyInjection
+{
+    public static IServiceCollection AddInfrastructure(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        // TODO: services.AddDbContext<FeatureFlagDbContext>(...)
+        // TODO: services.AddScoped<IFeatureFlagRepository, FeatureFlagRepository>()
+
+        return services;
+    }
+}
+```
+
+---
+
+### 5.3 Program.cs — Composition Root
+
+**Location:** `FeatureFlag.Api/Program.cs`
+
+Replace the two commented-out lines that already exist in the file:
+
+```csharp
+builder.Services.AddApplication();
+builder.Services.AddInfrastructure(builder.Configuration);
+```
+
+---
+
+## 6. Folder Structure After Implementation
+
+```
+FeatureFlag.Application/
+  DependencyInjection.cs
+  Evaluation/
+    FeatureEvaluator.cs
+  Interfaces/
+    IFeatureFlagService.cs
+  Services/
+    FeatureFlagService.cs
+  Strategies/
+    NoneStrategy.cs
+    PercentageStrategy.cs
+    RoleStrategy.cs
+
+FeatureFlag.Domain/
+  Interfaces/
+    IRolloutStrategy.cs          ← UPDATE: add StrategyType property
+    IFeatureFlagRepository.cs    ← CREATE
+
+FeatureFlag.Infrastructure/
+  DependencyInjection.cs         ← CREATE (stub only)
+```
+
+---
+
+## 7. Design Decisions — Quick Reference
+
+| Decision | Rationale |
+|---|---|
+| Registry dispatch over `switch` | Adding a new strategy requires only a new class and one DI registration line. `FeatureEvaluator` never changes. Satisfies the Open/Closed Principle. |
+| SHA256 over `GetHashCode()` | `GetHashCode()` is randomized per process in .NET. It produces different values across restarts. SHA256 is stable, deterministic, and trusted. |
+| `uint` for bucket comparison | SHA256 bytes converted to `int` can be negative. A negative bucket silently breaks the less-than comparison. `uint` is always non-negative — safe by type. |
+| `UserId + FlagName` in hash | Hashing `UserId` alone means the same users are always in every rollout. Including the flag name creates an independent distribution per flag. |
+| OR logic in `RoleStrategy` | Most role-based flags mean "any of these roles." AND logic usually signals that role design needs improvement upstream, not that the strategy should be more complex. |
+| `HashSet` for role lookup | O(1) lookup vs O(n) for `List`. `OrdinalIgnoreCase` handles provider mismatches like `"Admin"` vs `"admin"` silently and correctly. |
+| Fail closed on bad config | Both strategies return `false` when config is null, malformed, or out of range. A broken flag disables the feature — it does not grant access. |
+| `NoneStrategy` as a class | Avoids a conditional in `FeatureEvaluator`. Every enum value maps to a strategy. The evaluator stays free of branching logic. |
+| Scoped service lifetime | `FeatureFlagService` depends on `IFeatureFlagRepository` which wraps EF Core `DbContext` — a Scoped service. Matching lifetimes prevents the captive dependency bug. |
+| `IFeatureFlagRepository` in Domain | Infrastructure implements it. Domain defines it. Application consumes it. This is the Dependency Inversion Principle — high-level policy does not depend on low-level detail. |
+
+---
+
+## 8. Instructions for Claude Code
+
+Read the following before writing any code:
+
+- `CLAUDE.md`
+- `docs/roadmap.md`
+- `docs/architecture.md`
+- `docs/current-state.md`
+- This file
+
+Then implement in this order:
+
+1. Update `IRolloutStrategy` in Domain — add the `StrategyType` property
+2. Create `IFeatureFlagRepository` in Domain
+3. Implement `NoneStrategy`, `PercentageStrategy`, and `RoleStrategy` in `Application/Strategies/`
+4. Implement `FeatureEvaluator` in `Application/Evaluation/`
+5. Implement `FeatureFlagService` in `Application/Services/`
+6. Create `DependencyInjection.cs` in Application with `AddApplication()` extension method
+7. Create `DependencyInjection.cs` stub in Infrastructure with `AddInfrastructure()` extension method
+8. Wire up `AddApplication()` and `AddInfrastructure()` in `Program.cs`
+9. Verify the solution builds: `dotnet build FeatureFlagService.sln`
+
+> **DO NOT**  
+> Do not implement EF Core, `DbContext`, or the real repository — that is a separate session.  
+> Do not add controllers or Swagger changes.  
+> Do not modify `Flag.cs`, `FeatureEvaluationContext.cs`, or any existing domain entity.  
+> Do not change `RolloutStrategy.cs` or `EnvironmentType.cs`.  
+> Do not add NuGet packages without confirming first.
+
+---
+
+*FeatureFlagService | feature/evaluation-engine | Phase 0*

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -25,7 +25,7 @@ Build a production-style feature flag service that supports:
 
 ### Application Layer
 
-* [ ] Define `IFeatureFlagService` interface
+* [x] Define `IFeatureFlagService` interface
 * [ ] Implement `FeatureEvaluator`
 * [ ] Separate evaluation logic from domain
 


### PR DESCRIPTION
- Add StrategyType property to IRolloutStrategy for registry dispatch
- Create IFeatureFlagRepository interface in Domain
- Implement NoneStrategy, PercentageStrategy, and RoleStrategy
- Implement FeatureEvaluator using dictionary-based strategy dispatch
- Implement FeatureFlagService orchestrating repository + evaluator
- Add DependencyInjection extension methods for Application and Infrastructure
- Wire AddApplication() and AddInfrastructure() in Program.cs
- Add Microsoft.Extensions abstractions packages to Application and Infrastructure
- Document implementation decisions and known issues