### PR TITLE
docs: add PR links to all decision specs and implementation notes

### DIFF
--- a/Docs/Decisions/evaluation-engine/implementation-notes.md
+++ b/Docs/Decisions/evaluation-engine/implementation-notes.md
@@ -4,7 +4,8 @@
 **Branch:** `feature/evaluation-engine`  
 **Spec reference:** `docs/Decisions/evaluation-engine/spec.md`  
 **Build status:** Passed — 0 warnings, 0 errors
-**PR:** —
+
+[Pull Request #22](https://github.com/amodelandme/FeatureFlagService/pull/22)
  
 ---
  

--- a/Docs/Decisions/evaluation-engine/spec.md
+++ b/Docs/Decisions/evaluation-engine/spec.md
@@ -4,7 +4,8 @@
 **Phase:** 0 — Foundation  
 **Status:** Ready for implementation
 **Implementation notes:** `docs/Decisions/evaluation-engine/implementation-notes.md`
-**PR:** —
+
+[Pull Request #22](https://github.com/amodelandme/FeatureFlagService/pull/22)
 
 ---
 

--- a/Docs/Decisions/persistence-and-controllers/implementation-notes.md
+++ b/Docs/Decisions/persistence-and-controllers/implementation-notes.md
@@ -5,7 +5,8 @@
 **Spec reference:** `docs/Decisions/persistence-and-controllers/spec.md`
 **Build status:** Passed — 0 warnings, 0 errors
 **Tests:** 8/8 passing
-**PR:** —
+
+[Pull Request #24](https://github.com/amodelandme/FeatureFlagService/pull/24)
 
 ---
 

--- a/Docs/Decisions/persistence-and-controllers/spec-v1.md
+++ b/Docs/Decisions/persistence-and-controllers/spec-v1.md
@@ -4,6 +4,8 @@
 **Phase:** 0 — Foundation (Completion)
 **Status:** Ready for implementation
 
+[Pull Request #24](https://github.com/amodelandme/FeatureFlagService/pull/24)
+
 ---
 
 ## 1. Purpose of This Document

--- a/Docs/Decisions/persistence-and-controllers/spec.md
+++ b/Docs/Decisions/persistence-and-controllers/spec.md
@@ -5,7 +5,8 @@
 **Status:** Ready for implementation
 **Revision:** v2 — updated after Senior Engineer code review
 **Implementation notes:** `docs/Decisions/persistence-and-controllers/implementation-notes.md`
-**PR:** —
+
+[Pull Request #24](https://github.com/amodelandme/FeatureFlagService/pull/24)
 
 ---
 

--- a/Docs/Decisions/refactor-service-interface-dtos/implementation-notes.md
+++ b/Docs/Decisions/refactor-service-interface-dtos/implementation-notes.md
@@ -6,7 +6,8 @@
 **Build status:** Passed — 0 warnings, 0 errors
 **Tests:** 8/8 passing
 **Smoke test:** Passed — POST, GET, PUT, DELETE all return correct responses
-**PR:** 27 
+
+[Pull Request #27](https://github.com/amodelandme/FeatureFlagService/pull/27)
 
 ---
 

--- a/Docs/Decisions/refactor-service-interface-dtos/spec.md
+++ b/Docs/Decisions/refactor-service-interface-dtos/spec.md
@@ -4,7 +4,9 @@
 `refactor/service-interface-dtos`
 
 **Implementation notes:** `docs/Decisions/refactor-service-interface-dtos/implementation-notes.md`
-**PR:** —
+
+[Pull Request #24](https://github.com/amodelandme/FeatureFlagService/pull/24)
+
 
 ## Problem
 

--- a/Docs/Decisions/upgrade-net10/implementation-notes.md
+++ b/Docs/Decisions/upgrade-net10/implementation-notes.md
@@ -5,7 +5,8 @@
 **Spec reference:** `docs/Decisions/upgrade-net10/spec.md`
 **Build status:** Passed — 0 warnings, 0 errors
 **Test status:** Passed — 8/8
-**PR:** —
+
+[Pull Request #23](https://github.com/amodelandme/FeatureFlagService/pull/23)
 
 ---
 

--- a/Docs/Decisions/upgrade-net10/spec.md
+++ b/Docs/Decisions/upgrade-net10/spec.md
@@ -5,7 +5,8 @@
 **Status:** Ready for implementation  
 **Estimated scope:** Small — two files changed, five `.csproj` files updated
 **Implementation notes:** `docs/Decisions/upgrade-net10/implementation-notes.md`
-**PR:** —
+
+[Pull Request #23](https://github.com/amodelandme/FeatureFlagService/pull/23)
 
 ---
 


### PR DESCRIPTION
## Summary

- Replaced `PR: —` placeholders with live GitHub PR links across all decision specs and implementation notes
- Covers: evaluation-engine (#22), persistence-and-controllers (#24), upgrade-net10 (#23), refactor-service-interface-dtos (#26)