### PR TITLE
feat: implement FluentValidation on request DTOs — closes KI-003

### DIFF
--- a/Docs/Decisions/fluent-validation/implementation-notes.md
+++ b/Docs/Decisions/fluent-validation/implementation-notes.md
@@ -1,0 +1,108 @@
+# FluentValidation — Implementation Notes
+
+**Session date:** 2026-03-28
+**Branch:** `feature/fluent-validation-dtos`
+**Spec reference:** `Docs/Decisions/fluent-validation/spec.md`
+**Build status:** Passed — 0 warnings, 0 errors
+**Tests:** 8/8 passing
+**PR:** —
+
+---
+
+## What Was Implemented
+
+- `InputSanitizer` — internal static helper in `FeatureFlag.Application/Validators/`
+- `CreateFlagRequestValidator` — Name regex + length, env sentinel, StrategyConfig cross-field rules
+- `UpdateFlagRequestValidator` — StrategyConfig cross-field rules
+- `EvaluationRequestValidator` — FlagName/UserId length + empty, UserRoles null/count/per-role length
+- `DependencyInjection.cs` — explicit `IValidator<T>` registrations
+- `FeatureFlagService.IsEnabledAsync` — sanitizes `UserId` and `UserRoles` before building context
+- `FeatureFlagService.CreateFlagAsync` — sanitizes `Name` before constructing `Flag`
+- `FeatureFlagsController` — manual `ValidateAsync` on POST and PUT
+- `EvaluationController` — manual `ValidateAsync` before `FeatureEvaluationContext` is constructed
+
+---
+
+## Deviations from Spec
+
+### DEV-001 — `AddValidatorsFromAssemblyContaining` Not Used
+
+**Reason:** `AddValidatorsFromAssemblyContaining` lives in
+`FluentValidation.DependencyInjectionExtensions` — a separate NuGet package not bundled
+in the core `FluentValidation` package. The spec was incorrect on this point.
+
+**Fix:** Explicit `AddScoped<IValidator<T>, TValidator>()` registrations in
+`DependencyInjection.cs`.
+
+**Impact:** Zero behavior change. More transparent — a new engineer reading
+`DependencyInjection.cs` sees exactly what is registered without chasing an assembly
+scan. Assembly scanning earns its complexity at dozens of validators, not three.
+
+**Spec update required:** Replace `AddValidatorsFromAssemblyContaining` with explicit
+registrations. Remove the claim that DI extensions are bundled in core.
+
+---
+
+### DEV-002 — RuleFor Sanitization Pattern Changed
+
+**Reason:** Calling `RuleFor(x => InputSanitizer.Clean(x.Name)).OverridePropertyName()`
+hits a type inference limitation in FluentValidation v12. When the lambda passed to
+`RuleFor` returns a value via a static method call, the compiler cannot always infer
+`TProperty` for the extension method chain.
+
+**Fix:** Validate structural constraints on the raw property; run sanitized value through
+`Must()` for the regex check:
+
+```csharp
+RuleFor(x => x.Name)
+    .NotEmpty().WithMessage("Flag name is required.")
+    .MaximumLength(100).WithMessage("Flag name must not exceed 100 characters.")
+    .Must(name => Regex.IsMatch(
+        InputSanitizer.Clean(name) ?? string.Empty,
+        @"^[a-zA-Z0-9\-_]+$"))
+    .WithMessage("Flag name may only contain letters, numbers, hyphens, and underscores.");
+```
+
+**Why this is semantically equivalent:**
+- `NotEmpty` runs on the raw value — `" "` (whitespace-only) is treated as empty by
+  FluentValidation and returns a validation failure. ✅
+- `MaximumLength(100)` runs on the raw value — a 101-character string with spaces is
+  still too long after trimming. ✅
+- The regex `Must()` runs the sanitized value through the check — the only rule where
+  sanitization actually changes the outcome. `" dark-mode "` → cleaned to `"dark-mode"`
+  → passes regex. ✅
+
+**Pattern to follow:** Any future validator that needs sanitization-aware rules uses this
+same `Must()` pattern — validate structural constraints raw, run cleaned value through
+`Must()` for rules where sanitization changes the outcome.
+
+**Spec update required:** Document this as the v12 approach. Remove `.Transform()` and
+`OverridePropertyName` from any future spec examples.
+
+---
+
+## Known Issues (New)
+
+### KI-NEW-001 — `BeValidPercentageConfig` / `BeValidRoleConfig` Duplicated
+
+`BeValidPercentageConfig` and `BeValidRoleConfig` are private static methods duplicated
+identically in both `CreateFlagRequestValidator` and `UpdateFlagRequestValidator`.
+
+**Candidate fix:** Extract to a `StrategyConfigRules` internal static class in
+`FeatureFlag.Application/Validators/`. Both validators call the shared methods.
+
+**Deferred:** Not a Phase 1 blocker. Candidate for a small cleanup spec.
+
+---
+
+## Notes
+
+- `InputSanitizer` is `internal` — accessible from `FeatureFlagService` (same project)
+  but not from the Api project. This is intentional.
+- `StrategyConfig` is intentionally not sanitized — it is JSON, stored verbatim; only
+  its length and internal structure are validated.
+- `FluentValidation.AspNetCore` was not added — it is deprecated. Manual `ValidateAsync`
+  in controllers is the correct v12 approach.
+- Architecture.md references auto-validation and `.Transform()` — both are now outdated.
+  Update architecture.md to reflect the v12 manual validation approach. *(Deferred to
+  end of session.)*

--- a/Docs/Decisions/fluent-validation/spec.md
+++ b/Docs/Decisions/fluent-validation/spec.md
@@ -39,17 +39,38 @@ This spec adds two things:
    DTOs, wired into the ASP.NET Core pipeline via auto-validation so invalid requests
    are rejected at the HTTP boundary with a structured `400 Bad Request`.
 
-### Important: Why a Shared Sanitizer, Not Just `.Transform()`
+### Important: Why a Shared Sanitizer, Not Just Validator-Level Sanitization
 
-FluentValidation's `.Transform()` sanitizes a value *for the purpose of validation
-only* — it does not mutate the DTO. The service layer receives the original,
-unsanitized value. This matters: `" Admin "` (with spaces) would pass validation
-after being trimmed to `"Admin"`, but `RoleStrategy` would receive `" Admin "` and
-the `HashSet` comparison would silently fail — a legitimate user denied access.
+FluentValidation v12 removed `.Transform()`. The v12 pattern for sanitization-aware
+validation is to validate structural constraints on the raw property and run the cleaned
+value through `Must()` for rules where sanitization changes the outcome:
 
-The fix: `InputSanitizer` is a shared static helper. Validators call it via
-`.Transform()`. The service layer calls it directly before using string values in
-evaluation logic. Same rules, one source of truth.
+```csharp
+RuleFor(x => x.Name)
+    .NotEmpty().WithMessage("Flag name is required.")
+    .MaximumLength(100).WithMessage("Flag name must not exceed 100 characters.")
+    .Must(name => Regex.IsMatch(
+        InputSanitizer.Clean(name) ?? string.Empty,
+        @"^[a-zA-Z0-9\-_]+$"))
+    .WithMessage("Flag name may only contain letters, numbers, hyphens, and underscores.");
+```
+
+`NotEmpty` and `MaximumLength` run on the raw value — a 101-character string with spaces
+is still too long after trimming, and whitespace-only strings are treated as empty by
+FluentValidation. The `Must()` lambda runs the sanitized value through the regex — the
+only check where sanitization actually changes the outcome.
+
+**Note:** `RuleFor(x => InputSanitizer.Clean(x.Name)).OverridePropertyName("Name")` hits
+a type inference limitation in v12 when a static method is used in the lambda. Use the
+`Must()` pattern above instead for all sanitization-aware rules.
+
+This still does not mutate the DTO — the service layer receives the original, raw value. This matters: `" Admin "` (with spaces) would pass validation after being cleaned
+to `"Admin"`, but `RoleStrategy` would receive `" Admin "` and the `HashSet` comparison
+would silently fail — a legitimate user denied access.
+
+The fix is unchanged: `InputSanitizer` is a shared static helper. Validators call it
+inside `Must()` lambdas. The service layer calls it directly before using string values
+in evaluation logic. Same rules, one source of truth.
 
 ---
 
@@ -57,17 +78,14 @@ evaluation logic. Same rules, one source of truth.
 
 ### `FeatureFlag.Application/FeatureFlag.Application.csproj`
 ```xml
-<PackageReference Include="FluentValidation" Version="11.*" />
+<PackageReference Include="FluentValidation" Version="12.*" />
 ```
 
-### `FeatureFlag.Api/FeatureFlag.Api.csproj`
-```xml
-<PackageReference Include="FluentValidation.AspNetCore" Version="11.*" />
-```
-
-> **Note:** `FluentValidation` (core rules) belongs in Application — that layer owns
-> validation logic. `FluentValidation.AspNetCore` (auto-validation middleware) belongs
-> in Api — that layer plugs into the HTTP pipeline.
+> **Note:** `FluentValidation.AspNetCore` is **deprecated** as of v11 and should not
+> be added. Validation is wired manually in controllers using injected `IValidator<T>`
+> instances. `AddValidatorsFromAssemblyContaining` lives in the separate
+> `FluentValidation.DependencyInjectionExtensions` package — do not add it. Register
+> validators explicitly in `DependencyInjection.cs` instead (see Files to Modify).
 
 ---
 
@@ -79,7 +97,7 @@ All new files go in: `FeatureFlag.Application/Validators/`
 
 ### 1. `InputSanitizer.cs`
 
-Shared sanitization logic. Used by validators (via `.Transform()`) and by
+Shared sanitization logic. Used by validators (via `Must()` lambdas) and by
 `FeatureFlagService` directly. Any future input surface (CLI, seed data) must also
 call this helper — do not inline equivalent logic elsewhere.
 
@@ -143,9 +161,10 @@ public sealed class CreateFlagRequestValidator : AbstractValidator<CreateFlagReq
 {
     public CreateFlagRequestValidator()
     {
-        // Sanitize then validate Name
-        RuleFor(x => x.Name)
-            .Transform(name => InputSanitizer.Clean(name))
+        // Sanitize inside the RuleFor lambda (v12: .Transform() removed).
+        // OverridePropertyName required — property name cannot be inferred from a lambda.
+        RuleFor(x => InputSanitizer.Clean(x.Name))
+            .OverridePropertyName("Name")
             .NotEmpty().WithMessage("Flag name is required.")
             .MaximumLength(100).WithMessage("Flag name must not exceed 100 characters.")
             .Matches(@"^[a-zA-Z0-9\-_]+$")
@@ -311,15 +330,14 @@ public sealed class EvaluationRequestValidator : AbstractValidator<EvaluationReq
 {
     public EvaluationRequestValidator()
     {
-        // Sanitize then validate FlagName
-        RuleFor(x => x.FlagName)
-            .Transform(name => InputSanitizer.Clean(name))
+        // Sanitize inside the RuleFor lambda (v12: .Transform() removed).
+        RuleFor(x => InputSanitizer.Clean(x.FlagName))
+            .OverridePropertyName("FlagName")
             .NotEmpty().WithMessage("FlagName is required.")
             .MaximumLength(100).WithMessage("FlagName must not exceed 100 characters.");
 
-        // Sanitize then validate UserId
-        RuleFor(x => x.UserId)
-            .Transform(id => InputSanitizer.Clean(id))
+        RuleFor(x => InputSanitizer.Clean(x.UserId))
+            .OverridePropertyName("UserId")
             .NotEmpty().WithMessage("UserId is required.")
             .MaximumLength(256).WithMessage("UserId must not exceed 256 characters.");
 
@@ -337,9 +355,9 @@ public sealed class EvaluationRequestValidator : AbstractValidator<EvaluationReq
             .WithMessage("UserRoles must not exceed 50 entries.")
             .When(x => x.UserRoles is not null);
 
+        // Validate cleaned length per role — consistent with service-layer sanitization behavior
         RuleForEach(x => x.UserRoles)
-            .Transform(role => InputSanitizer.Clean(role))
-            .MaximumLength(100)
+            .Must(role => (InputSanitizer.Clean(role)?.Length ?? 0) <= 100)
             .WithMessage("Each role must not exceed 100 characters.")
             .When(x => x.UserRoles is not null);
     }
@@ -359,6 +377,7 @@ using FeatureFlag.Application.Evaluation;
 using FeatureFlag.Application.Interfaces;
 using FeatureFlag.Application.Services;
 using FeatureFlag.Application.Strategies;
+using FeatureFlag.Application.Validators;
 using FeatureFlag.Domain.Interfaces;
 using FluentValidation;
 using Microsoft.Extensions.DependencyInjection;
@@ -369,8 +388,12 @@ public static class DependencyInjection
 {
     public static IServiceCollection AddApplication(this IServiceCollection services)
     {
-        // Validators — scans entire Application assembly; registers all AbstractValidator<T> types
-        services.AddValidatorsFromAssemblyContaining<Validators.CreateFlagRequestValidator>();
+        // Validators — registered explicitly; IValidator<T> injected into controllers.
+        // AddValidatorsFromAssemblyContaining lives in FluentValidation.DependencyInjectionExtensions
+        // (separate package) — do not use it. Explicit registration is clearer for 3 validators.
+        services.AddScoped<IValidator<DTOs.CreateFlagRequest>, CreateFlagRequestValidator>();
+        services.AddScoped<IValidator<DTOs.UpdateFlagRequest>, UpdateFlagRequestValidator>();
+        services.AddScoped<IValidator<DTOs.EvaluationRequest>, EvaluationRequestValidator>();
 
         // Strategies — Singleton: stateless, safe to share across requests
         services.AddSingleton<IRolloutStrategy, NoneStrategy>();
@@ -392,27 +415,9 @@ public static class DependencyInjection
 
 ### `FeatureFlag.Api/Program.cs`
 
-Replace the `.AddControllers()` chain with:
-
-```csharp
-builder.Services
-    .AddControllers()
-    .AddJsonOptions(options =>
-    {
-        options.JsonSerializerOptions.Converters.Add(
-            new System.Text.Json.Serialization.JsonStringEnumConverter()
-        );
-    })
-    .AddFluentValidation(config =>
-    {
-        // Reject invalid requests at the HTTP boundary before controller actions execute.
-        // Returns 400 Bad Request with ValidationProblemDetails shape.
-        config.AutomaticValidationEnabled = true;
-    });
-```
-
-> `AddFluentValidation()` must be chained onto `AddControllers()` — it is an extension
-> method from `FluentValidation.AspNetCore`, not a standalone `services.Add...()` call.
+No changes required. `AddControllers()` stays exactly as-is. Do not add
+`AddFluentValidationAutoValidation()` — `FluentValidation.AspNetCore` is deprecated
+and not installed. Validation is handled manually in each controller action.
 
 ---
 
@@ -432,9 +437,10 @@ public async Task<bool> IsEnabledAsync(
     // Sanitize evaluation inputs. .Transform() in validators does not mutate the DTO.
     // UserId and UserRoles must be cleaned here to ensure consistent SHA256 hashing
     // in PercentageStrategy and HashSet lookups in RoleStrategy.
+    // Note: FeatureEvaluationContext constructor accepts IEnumerable<string> for userRoles.
     var sanitizedContext = new FeatureEvaluationContext(
         userId: Validators.InputSanitizer.Clean(context.UserId) ?? context.UserId,
-        roles: Validators.InputSanitizer.CleanCollection(context.UserRoles),
+        userRoles: Validators.InputSanitizer.CleanCollection(context.UserRoles),
         environment: context.Environment
     );
 
@@ -474,12 +480,75 @@ public async Task<FlagResponse> CreateFlagAsync(
 }
 ```
 
-> **Note on `FeatureEvaluationContext`:** Check whether its constructor accepts
-> `IEnumerable<string>` for roles. If it requires a specific immutable collection type,
-> wrap `InputSanitizer.CleanCollection()` output accordingly. Do not change the
-> `FeatureEvaluationContext` constructor signature.
+---
+
+### `FeatureFlag.Api/Controllers/FeatureFlagsController.cs`
+
+Inject `IValidator<CreateFlagRequest>` and `IValidator<UpdateFlagRequest>` and validate
+manually at the top of each mutating action. Read operations (GET) require no changes.
+
+Add constructor parameters:
+
+```csharp
+private readonly IFeatureFlagService _service;
+private readonly IValidator<CreateFlagRequest> _createValidator;
+private readonly IValidator<UpdateFlagRequest> _updateValidator;
+
+public FeatureFlagsController(
+    IFeatureFlagService service,
+    IValidator<CreateFlagRequest> createValidator,
+    IValidator<UpdateFlagRequest> updateValidator)
+{
+    _service = service;
+    _createValidator = createValidator;
+    _updateValidator = updateValidator;
+}
+```
+
+Add validation at the top of the `POST` action:
+
+```csharp
+var validation = await _createValidator.ValidateAsync(request, ct);
+if (!validation.IsValid)
+    return ValidationProblem(new ValidationProblemDetails(validation.ToDictionary()));
+```
+
+Add validation at the top of the `PUT` action:
+
+```csharp
+var validation = await _updateValidator.ValidateAsync(request, ct);
+if (!validation.IsValid)
+    return ValidationProblem(new ValidationProblemDetails(validation.ToDictionary()));
+```
 
 ---
+
+### `FeatureFlag.Api/Controllers/EvaluationController.cs`
+
+Inject `IValidator<EvaluationRequest>` and validate manually before constructing the
+context.
+
+Add constructor parameter:
+
+```csharp
+private readonly IFeatureFlagService _service;
+private readonly IValidator<EvaluationRequest> _validator;
+
+public EvaluationController(IFeatureFlagService service, IValidator<EvaluationRequest> validator)
+{
+    _service = service;
+    _validator = validator;
+}
+```
+
+Add validation at the top of the `POST` action, before the `FeatureEvaluationContext`
+is constructed:
+
+```csharp
+var validation = await _validator.ValidateAsync(request, ct);
+if (!validation.IsValid)
+    return ValidationProblem(new ValidationProblemDetails(validation.ToDictionary()));
+```
 
 ## Acceptance Criteria
 
@@ -538,9 +607,12 @@ All `400` responses return `ValidationProblemDetails`:
 }
 ```
 
-### AC-8: No controller changes required
-- `FeatureFlagsController` and `EvaluationController` require no modifications
-- Invalid requests never reach controller action methods
+### AC-8: Controller validation wiring
+- `FeatureFlagsController` POST and PUT actions return `400` with
+  `ValidationProblemDetails` shape before any service layer code runs
+- `EvaluationController` POST action returns `400` before `FeatureEvaluationContext`
+  is constructed
+- GET and DELETE actions in `FeatureFlagsController` require no changes
 
 ### AC-9: Build integrity
 - `dotnet build` passes with 0 warnings and 0 errors
@@ -551,19 +623,31 @@ All `400` responses return `ValidationProblemDetails`:
 ## What NOT to Do
 
 - Do not add `[Required]` data annotations to DTOs — FluentValidation replaces that
-- Do not add validation logic inside `FeatureFlagService` beyond the sanitization calls described above
+- Do not add `FluentValidation.AspNetCore` — it is deprecated; use manual validation
+  in controllers instead
+- Do not use `.Transform()` — removed in FluentValidation v12; use `RuleFor(x =>
+  InputSanitizer.Clean(x.Field)).OverridePropertyName("Field")` instead
+- Do not add validation logic inside `FeatureFlagService` beyond the sanitization
+  calls described above
 - Do not sanitize `StrategyConfig` content — it is JSON and must be stored verbatim;
   only its length and structure are validated
 - Do not modify the `Flag` domain entity
 - Do not modify `IFeatureFlagService`
 - Do not change `StrategyConfig` from `string` to `JsonDocument`
-- Do not inline sanitization logic — always call `InputSanitizer.Clean()` or `CleanCollection()`
+- Do not inline sanitization logic — always call `InputSanitizer.Clean()` or
+  `CleanCollection()`
 
 ---
 
 ## Folder Structure After This Change
 
 ```
+FeatureFlag.Api/
+├── Controllers/
+│   ├── FeatureFlagsController.cs    ← MODIFIED (POST + PUT manual validation)
+│   └── EvaluationController.cs      ← MODIFIED (POST manual validation)
+└── Program.cs                        ← NO CHANGES
+
 FeatureFlag.Application/
 ├── DTOs/
 │   ├── CreateFlagRequest.cs
@@ -576,15 +660,15 @@ FeatureFlag.Application/
 ├── Interfaces/
 │   └── IFeatureFlagService.cs
 ├── Services/
-│   └── FeatureFlagService.cs    ← MODIFIED
+│   └── FeatureFlagService.cs        ← MODIFIED (sanitization calls added)
 ├── Strategies/
 │   ├── NoneStrategy.cs
 │   ├── PercentageStrategy.cs
 │   └── RoleStrategy.cs
-├── Validators/                  ← NEW FOLDER
-│   ├── InputSanitizer.cs        ← NEW
+├── Validators/                       ← NEW FOLDER
+│   ├── InputSanitizer.cs             ← NEW
 │   ├── CreateFlagRequestValidator.cs
 │   ├── UpdateFlagRequestValidator.cs
 │   └── EvaluationRequestValidator.cs
-└── DependencyInjection.cs       ← MODIFIED
+└── DependencyInjection.cs            ← MODIFIED
 ```

--- a/Docs/current-state.md
+++ b/Docs/current-state.md
@@ -1,15 +1,33 @@
 # Current State — FeatureFlagService
 
+---
+
+## Table of Contents
+
+- [Status Summary](#-status-summary)
+- [What Is Completed](#-what-is-completed)
+- [What Is Not Yet Built](#-what-is-not-yet-built-phase-1-remaining)
+- [Known Issues](#-known-issues)
+- [Current Focus](#-current-focus)
+- [What Not To Do Right Now](#-what-not-to-do-right-now)
+- [Definition of Done — Phase 1](#-definition-of-done--phase-1)
+- [Notes for AI Assistants](#-notes-for-ai-assistants)
+
+---
+
 ## 📍 Status Summary
 
-**Phase 0 — Foundation: ✅ Complete**
-**Phase 1 — Architectural Cleanup: ✅ Complete**
+**Phase 0 — Foundation: ✅ Complete**  
+**Phase 1 — Architectural Cleanup: ✅ Complete**  
+**Phase 1 — Validation, Testing, Developer Experience: 🔄 In Progress**
 
 The full stack is implemented, smoke-tested, and verified. The service interface
 boundary has been cleaned up — domain entities no longer cross the service layer.
 The API is running against a local Postgres instance via Docker.
 
-**Next focus: Phase 1 — Validation, Testing, and Developer Experience**
+**Product direction locked:** Azure-native, .NET-first, AI-assisted feature flag
+platform targeting .NET teams on Azure. Phase 1.5 introduces Key Vault, Application
+Insights, and the AI analysis endpoint immediately after Phase 1 completes.
 
 ---
 
@@ -18,8 +36,9 @@ The API is running against a local Postgres instance via Docker.
 ### Domain Layer
 
 - `Flag` entity with controlled mutation (private setters, explicit update methods)
-- `Flag.Update()` — atomic method that sets enabled state, strategy, and `UpdatedAt` in one operation
-- `FeatureEvaluationContext` value object — `IEquatable<T>` implemented, guard clauses, immutable roles
+- `Flag.Update()` — atomic method that sets enabled state, strategy, and `UpdatedAt`
+- `FeatureEvaluationContext` value object — `IEquatable<T>`, guard clauses,
+  immutable `IReadOnlyList<string>` roles, accepts `IEnumerable<string>` on construction
 - `RolloutStrategy` enum (None, Percentage, RoleBased)
 - `EnvironmentType` enum (None = 0 sentinel, Development, Staging, Production)
 - `IRolloutStrategy` interface — includes `StrategyType` property for registry dispatch
@@ -33,8 +52,10 @@ The API is running against a local Postgres instance via Docker.
 - `FeatureEvaluator` — registry dispatch pattern, dictionary keyed by `RolloutStrategy`
 - `FeatureFlagService` — async, orchestrates repository + evaluator
 - `DependencyInjection.cs` — `AddApplication()` extension method
-- DTOs: `CreateFlagRequest`, `UpdateFlagRequest`, `FlagResponse`, `EvaluationRequest`, `FlagMappings`
-- `IFeatureFlagService` — async signatures with `CancellationToken`, full CRUD + evaluation
+- DTOs: `CreateFlagRequest`, `UpdateFlagRequest`, `FlagResponse`, `EvaluationRequest`,
+  `FlagMappings`
+- `IFeatureFlagService` — async signatures with `CancellationToken`, full CRUD +
+  evaluation
 
 ### Service Interface Boundary (refactor/service-interface-dtos) ✅
 
@@ -42,36 +63,47 @@ The API is running against a local Postgres instance via Docker.
 - All signatures use DTOs: `FlagResponse`, `CreateFlagRequest`, `UpdateFlagRequest`
 - `Flag` construction moved from controller into `FeatureFlagService.CreateFlagAsync`
 - `UpdateFlagAsync` accepts `UpdateFlagRequest` DTO — not 5 primitive parameters
-- `ToResponse()` mapping consolidated inside `FeatureFlagService` — called in exactly 3 places
-- `FeatureFlagsController` — zero `.ToResponse()` calls, zero `FeatureFlag.Domain.Entities` references
+- `ToResponse()` mapping consolidated inside `FeatureFlagService` — called in exactly
+  3 places
+- `FeatureFlagsController` — zero `.ToResponse()` calls, zero domain entity references
 - Smoke test verified: POST, GET, PUT, DELETE all return correct responses
 
 ### Infrastructure Layer
 
 - `FeatureFlagDbContext` — EF Core DbContext with `DbSet<Flag>`
-- `FlagConfiguration` — Fluent API entity config: enums as strings, `jsonb` for StrategyConfig,
+- `FlagConfiguration` — Fluent API: enums as strings, `jsonb` for StrategyConfig,
   partial unique index on `(Name, Environment)` filtered to non-archived flags
-- `FeatureFlagDbContextFactory` — design-time factory for deterministic `dotnet ef` tooling
+- `FeatureFlagDbContextFactory` — design-time factory for `dotnet ef` tooling
 - `FeatureFlagRepository` — async, `CancellationToken` on all EF Core calls
-- `DependencyInjection.cs` — `AddInfrastructure()` with Npgsql + DbContext + repository wiring
+- `DependencyInjection.cs` — `AddInfrastructure()` with Npgsql + DbContext + repository
 - `InitialCreate` migration — generated and applied
 
 ### API Layer
 
-- `FeatureFlagsController` — full CRUD: GET all, GET by name, POST, PUT, DELETE (soft archive)
+- `FeatureFlagsController` — full CRUD: GET all, GET by name, POST, PUT, DELETE
+  (soft archive)
 - `EvaluationController` — POST `/api/evaluate`, returns 404 for unknown flags
 - `Program.cs` — `JsonStringEnumConverter` wired, root redirect to OpenAPI docs
 - Swagger/OpenAPI configured and accessible at `/openapi/v1.json`
+
+### Documentation & Security
+
+- `Docs/architecture.md` — updated with product vision, validation/sanitization layer,
+  security model summary, Phase 1.5 future considerations
+- `Docs/roadmap.md` — updated with full product vision, Phase 1.5 through Phase 9,
+  .NET SDK as key product milestone
+- `Docs/Security/adr-input-security-model.md` — threat model, mitigations in place,
+  phase-gated deferred decisions
+- `Docs/Decisions/fluent-validation/spec.md` — Claude Code-ready implementation spec
 
 ### Dev Environment
 
 - DevContainer: `devcontainers/base:ubuntu-24.04` + .NET 10 SDK via `dotnet` feature
 - Docker-outside-of-Docker configured: host socket mounted
-- `dotnet-ef` added to `.config/dotnet-tools.json` — installed automatically via `dotnet tool restore`
-- `postStartCommand` in `devcontainer.json` joins `featureflagservice_default` Docker network on start
+- `dotnet-ef` added to `.config/dotnet-tools.json`
+- `postStartCommand` joins `featureflagservice_default` Docker network on start
 - Connection string: `Host=postgres` (Docker Compose service name — not `localhost`)
 - `docker-compose.yml` at repo root — one-command local Postgres setup
-- `docs/decisions/` folder established for Architecture Decision Records
 - All five `.csproj` files targeting `net10.0`
 
 ### Tests
@@ -84,33 +116,38 @@ The API is running against a local Postgres instance via Docker.
 
 ## ❌ What Is Not Yet Built (Phase 1 Remaining)
 
-### Validation
+### Validation & Sanitization
 
-- `FluentValidation` on `CreateFlagRequest`, `UpdateFlagRequest`, `EvaluationRequest` — KI-003 (Phase 1)
-- Name uniqueness check at the service layer before hitting the DB (Phase 1)
-
-### Testing
-
-- Unit tests for `PercentageStrategy`, `RoleStrategy`, `NoneStrategy` (Phase 1)
-- Unit tests for `FeatureEvaluator` — dispatch, missing strategy fallback (Phase 1)
-- Integration tests for all API endpoints including `/api/evaluate` (Phase 1)
+- `InputSanitizer` — shared static helper in `FeatureFlag.Application/Validators/`;
+  trims whitespace and strips control characters; called by validators and service layer
+- `CreateFlagRequestValidator` — Name allowlist regex, env sentinel guard,
+  StrategyConfig cross-field rules, 2000-char limit — closes KI-003
+- `UpdateFlagRequestValidator` — StrategyConfig cross-field rules, 2000-char limit
+- `EvaluationRequestValidator` — UserId max 256, UserRoles max 50×100,
+  env sentinel guard
+- `AddFluentValidationAutoValidation()` wired in `Program.cs` (FluentValidation v11 API)
+- `InputSanitizer` called in `FeatureFlagService.IsEnabledAsync` and `CreateFlagAsync`
+- Name uniqueness check at the service layer before hitting the DB
 
 ### Error Handling
 
-- Global exception middleware — currently using per-controller try/catch (Phase 1)
-- Standardized API error response shape (Phase 1)
+- Global exception middleware — currently using per-controller try/catch
+- Standardized `ValidationProblemDetails` error response shape
+- Route parameter guard for `{name}` on GET and PUT — closes KI-008
+
+### Testing
+
+- Unit tests for `PercentageStrategy`, `RoleStrategy`, `NoneStrategy`
+- Unit tests for `FeatureEvaluator` — dispatch, missing strategy fallback
+- Unit tests for all three validators — every acceptance criterion covered
+- Integration tests for all API endpoints including `/api/evaluate`
 
 ### Developer Experience
 
-- `.http` smoke test request file committed to repo (`requests/smoke-test.http`) (Phase 1)
-- Seed data for development/staging flags (Phase 1)
-- Logging for evaluation decisions (Phase 1)
-- OpenAPI enum schema fix — enums currently render as `integer` in spec (cosmetic) (Phase 1)
-
-### Authentication & Authorization
-
-- JWT or OAuth (Phase 3)
-- Role-based access to flag management endpoints (Phase 3)
+- `.http` smoke test request file committed to repo (`requests/smoke-test.http`)
+- Seed data for development/staging flags
+- Evaluation decision logging
+- OpenAPI enum schema fix — enums currently render as `integer` in spec (cosmetic)
 
 ---
 
@@ -118,61 +155,64 @@ The API is running against a local Postgres instance via Docker.
 
 ### KI-002 — `FeatureEvaluator.Evaluate` Has an Implicit Precondition
 
-**Severity:** Low — no bug today, potential footgun if the evaluator gains new callers
+**Severity:** Low  
 **Status:** Documented — tracked for review when new callers are introduced
 
-The evaluator is a pure strategy dispatcher. The precondition — that callers must check
-`Flag.IsEnabled` before calling `Evaluate` — is documented via XML doc comment on the
-method but is not enforced by a guard clause.
+Callers must check `Flag.IsEnabled` before calling `Evaluate`. This contract is
+documented via XML doc comment but not enforced by a guard clause.
 
 **Action required if:** A second caller of `FeatureEvaluator` is introduced anywhere
-in the codebase. At that point, re-evaluate whether the guard clause should be restored.
+in the codebase.
 
 ---
 
-### KI-003 — `StrategyConfig` Validation Is Deferred to Runtime
+### KI-003 — `StrategyConfig` Validation Deferred to Runtime
 
-**Severity:** Medium — misconfiguration fails silently at evaluation time
-**Status:** Deferred — Phase 1 requirement (next up)
-
-Both `PercentageStrategy` and `RoleStrategy` deserialize `Flag.StrategyConfig` at
-evaluation time and fail closed on bad config. There is no validation at flag creation time.
-
-**Planned fix:** `FluentValidation` validators on the request DTOs. Next task in Phase 1.
+**Severity:** Medium — misconfiguration fails silently at evaluation time  
+**Status:** Fix in progress — `Docs/Decisions/fluent-validation/spec.md` is the
+implementation spec. Closes when FluentValidation validators are implemented.
 
 ---
 
-### KI-006 — `Microsoft.EntityFrameworkCore.Design` Required on Both Infrastructure and Api
+### KI-006 — `Microsoft.EntityFrameworkCore.Design` Required on Both Projects
 
-**Severity:** Low — spec gap, not a runtime issue
+**Severity:** Low — spec gap, not a runtime issue  
 **Status:** Documented — handled during implementation
 
-The spec listed `Microsoft.EntityFrameworkCore.Design` for Infrastructure only.
-`dotnet ef` also requires it on the startup project (Api). Both projects carry the
-package with `PrivateAssets=all`.
-
-**Note for future specs:** Any spec that includes EF Core migration steps must list
-this package on both the Infrastructure and Api projects.
+Any spec that includes EF Core migration steps must list this package on both
+Infrastructure and Api projects with `PrivateAssets=all`.
 
 ---
 
 ### KI-007 — Devcontainer Networking Requires Postgres to Start First
 
-**Severity:** Low — inconvenience, not a bug
-**Status:** Mitigated — `postStartCommand` automates the network join on each container start
+**Severity:** Low — inconvenience, not a bug  
+**Status:** Mitigated — `postStartCommand` automates the network join
 
-The `postStartCommand` in `devcontainer.json` runs `docker network connect featureflagservice_default`
-on container start. If Postgres is not yet running at that moment (e.g., after a full
-machine restart), the join silently fails and the API cannot reach the database.
-
-**Workaround:** Run `docker compose up -d` before opening the devcontainer. If the
-devcontainer is already running:
+**Workaround:** Run `docker compose up -d` before opening the devcontainer.
+If devcontainer is already running:
 ```bash
 docker network connect featureflagservice_default $(cat /etc/hostname)
 ```
+**Longer-term fix:** Migrate to full docker-compose devcontainer setup. Deferred to
+Phase 8.
 
-**Longer-term fix:** Migrate devcontainer to a full docker-compose devcontainer setup
-so both services start together. Deferred — not a Phase 1 blocker. Tracked for Phase 8.
+---
+
+### KI-008 — Route Parameters on GET and PUT Lack Allowlist Validation
+
+**Severity:** Low  
+**Status:** Open — Phase 1 fix
+
+`GET /api/flags/{name}` and `PUT /api/flags/{name}/{environment}` accept a `name`
+route parameter with no character allowlist validation. Flag creation enforces
+`^[a-zA-Z0-9\-_]+$` on `Name`, but a caller can send arbitrary characters in the
+URL on GET and PUT. EF Core parameterized queries prevent SQL injection. The risk
+is unexpected characters reaching logs and repository method calls.
+
+**Planned fix:** Static `RouteParameterGuard.ValidateName(string name)` helper
+returning `400 Bad Request` for non-conforming values, called at the top of affected
+controller actions. See `Docs/Security/adr-input-security-model.md` DEFERRED-005.
 
 ---
 
@@ -182,11 +222,12 @@ so both services start together. Deferred — not a Phase 1 blocker. Tracked for
 
 ### Immediate Next Tasks
 
-1. Add `FluentValidation` to request DTOs — closes KI-003
-2. Add global exception middleware — closes per-controller try/catch pattern
-3. Unit tests for strategies and evaluator
-4. Integration tests for all endpoints
-5. Commit `.http` smoke test file to repo
+1. Implement `InputSanitizer` and all three FluentValidation validators — closes KI-003
+2. Add global exception middleware and standardized error shape
+3. Add route parameter guard for `{name}` on GET/PUT — closes KI-008
+4. Unit tests for strategies, evaluator, and all three validators
+5. Integration tests for all endpoints
+6. Commit `.http` smoke test file
 
 ---
 
@@ -195,33 +236,63 @@ so both services start together. Deferred — not a Phase 1 blocker. Tracked for
 - No authentication or authorization yet (Phase 3)
 - No caching layer yet (Phase 6)
 - No advanced rollout strategies yet (Phase 5)
-- No observability pipeline yet (Phase 4)
+- No observability pipeline yet (Phase 4) — App Insights comes in Phase 1.5
+- No AI analysis endpoint yet (Phase 1.5)
 - No UI work
 - Do not change `Host=postgres` back to `localhost` in connection string
+- Do not use `AddFluentValidation()` — that is the v9/v10 API; use
+  `AddFluentValidationAutoValidation()` (FluentValidation.AspNetCore v11)
 
 ---
 
 ## 📌 Definition of Done — Phase 1
 
-- [ ] `FluentValidation` on all request DTOs
+- [ ] `InputSanitizer` implemented and called in validators and service layer
+- [ ] `FluentValidation` on all three request DTOs with all acceptance criteria passing
+- [ ] `AddFluentValidationAutoValidation()` wired in `Program.cs`
 - [ ] Global exception middleware in place
-- [ ] Unit tests for all strategies and evaluator
+- [ ] Route parameter guard on GET/PUT — closes KI-008
+- [ ] Unit tests for all three strategies
+- [ ] Unit tests for `FeatureEvaluator`
+- [ ] Unit tests for all three validators
 - [ ] Integration tests for all 6 endpoints
 - [ ] `.http` smoke test file committed
 - [ ] Seed data for local development
 - [ ] Evaluation logging in place
+- [ ] Build: 0 warnings, 0 errors
+- [ ] All tests passing
 
 ---
 
 ## 🧩 Notes for AI Assistants
 
-- The system is not production-ready
-- Prioritize correctness over feature expansion
+### Architecture
 - Follow Clean Architecture — dependencies point inward toward Domain
-- Work within the established layer boundaries (Api → Application → Domain ← Infrastructure)
 - `IFeatureFlagService` speaks entirely in DTOs — never return `Flag` from the service
 - All evaluation logic must remain deterministic and isolated from persistence
-- See Known Issues above before modifying `FeatureEvaluator` or adding new callers
+- `FeatureEvaluationContext` constructor signature: `(string userId, IEnumerable<string> userRoles, EnvironmentType environment)`
 - `appsettings.Development.json` is intentionally committed — local Docker defaults only
 - Connection string uses `Host=postgres` — do not change to `localhost`
-- Both Infrastructure and Api projects require `Microsoft.EntityFrameworkCore.Design` with `PrivateAssets=all`
+- Both Infrastructure and Api projects require `Microsoft.EntityFrameworkCore.Design`
+  with `PrivateAssets=all`
+
+### Validation & Sanitization
+- FluentValidation v11 API: use `AddFluentValidationAutoValidation()` — not
+  `AddFluentValidation(config => ...)`
+- `InputSanitizer` is `internal` to `FeatureFlag.Application` — accessible from
+  `FeatureFlagService` in the same project, not from the Api project
+- Do not inline sanitization logic — always call `InputSanitizer.Clean()` or
+  `CleanCollection()`
+- Do not sanitize `StrategyConfig` — it is JSON, stored verbatim; only length and
+  structure are validated
+- Any new `IRolloutStrategy` requires a corresponding validator rule before the API
+  will accept its configuration
+
+### Security
+- See `Docs/Security/adr-input-security-model.md` before modifying the security boundary
+- Raw SQL via `FromSqlRaw()` with string concatenation is prohibited
+
+### Product Direction
+- This is an Azure-native, .NET-first, AI-assisted feature flag platform
+- Phase 1.5 immediately follows Phase 1 — do not skip or defer Azure/AI integration
+- See `Docs/roadmap.md` for the full phase plan and product vision

--- a/FeatureFlag.Api/Controllers/EvaluationController.cs
+++ b/FeatureFlag.Api/Controllers/EvaluationController.cs
@@ -1,6 +1,7 @@
 using FeatureFlag.Application.DTOs;
 using FeatureFlag.Application.Interfaces;
 using FeatureFlag.Domain.ValueObjects;
+using FluentValidation;
 using Microsoft.AspNetCore.Mvc;
 
 namespace FeatureFlag.Api.Controllers;
@@ -10,10 +11,12 @@ namespace FeatureFlag.Api.Controllers;
 public sealed class EvaluationController : ControllerBase
 {
     private readonly IFeatureFlagService _service;
+    private readonly IValidator<EvaluationRequest> _validator;
 
-    public EvaluationController(IFeatureFlagService service)
+    public EvaluationController(IFeatureFlagService service, IValidator<EvaluationRequest> validator)
     {
         _service = service;
+        _validator = validator;
     }
 
     [HttpPost]
@@ -21,6 +24,10 @@ public sealed class EvaluationController : ControllerBase
         [FromBody] EvaluationRequest request,
         CancellationToken ct)
     {
+        var validation = await _validator.ValidateAsync(request, ct);
+        if (!validation.IsValid)
+            return ValidationProblem(new ValidationProblemDetails(validation.ToDictionary()));
+
         try
         {
             var context = new FeatureEvaluationContext(

--- a/FeatureFlag.Api/Controllers/FeatureFlagsController.cs
+++ b/FeatureFlag.Api/Controllers/FeatureFlagsController.cs
@@ -1,6 +1,7 @@
 using FeatureFlag.Application.DTOs;
 using FeatureFlag.Application.Interfaces;
 using FeatureFlag.Domain.Enums;
+using FluentValidation;
 using Microsoft.AspNetCore.Mvc;
 
 namespace FeatureFlag.Api.Controllers;
@@ -10,10 +11,18 @@ namespace FeatureFlag.Api.Controllers;
 public sealed class FeatureFlagsController : ControllerBase
 {
     private readonly IFeatureFlagService _service;
+    private readonly IValidator<CreateFlagRequest> _createValidator;
+    private readonly IValidator<UpdateFlagRequest> _updateValidator;
 
-    public FeatureFlagsController(IFeatureFlagService service)
+    public FeatureFlagsController(
+        IFeatureFlagService service,
+        IValidator<CreateFlagRequest> createValidator,
+        IValidator<UpdateFlagRequest> updateValidator
+    )
     {
         _service = service;
+        _createValidator = createValidator;
+        _updateValidator = updateValidator;
     }
 
     [HttpGet]
@@ -47,6 +56,10 @@ public sealed class FeatureFlagsController : ControllerBase
         [FromBody] CreateFlagRequest request,
         CancellationToken ct)
     {
+        var validation = await _createValidator.ValidateAsync(request, ct);
+        if (!validation.IsValid)
+            return ValidationProblem(new ValidationProblemDetails(validation.ToDictionary()));
+
         var created = await _service.CreateFlagAsync(request, ct);
         return CreatedAtAction(
             nameof(GetByName),
@@ -61,6 +74,10 @@ public sealed class FeatureFlagsController : ControllerBase
         [FromBody] UpdateFlagRequest request,
         CancellationToken ct)
     {
+        var validation = await _updateValidator.ValidateAsync(request, ct);
+        if (!validation.IsValid)
+            return ValidationProblem(new ValidationProblemDetails(validation.ToDictionary()));
+
         try
         {
             await _service.UpdateFlagAsync(name, environment, request, ct);

--- a/FeatureFlag.Application/DependencyInjection.cs
+++ b/FeatureFlag.Application/DependencyInjection.cs
@@ -3,6 +3,8 @@ using FeatureFlag.Application.Interfaces;
 using FeatureFlag.Application.Services;
 using FeatureFlag.Application.Strategies;
 using FeatureFlag.Domain.Interfaces;
+using FeatureFlag.Application.Validators;
+using FluentValidation;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace FeatureFlag.Application;
@@ -11,6 +13,11 @@ public static class DependencyInjection
 {
     public static IServiceCollection AddApplication(this IServiceCollection services)
     {
+        // Validators — registered explicitly; IValidator<T> injected into controllers
+        services.AddScoped<IValidator<DTOs.CreateFlagRequest>, CreateFlagRequestValidator>();
+        services.AddScoped<IValidator<DTOs.UpdateFlagRequest>, UpdateFlagRequestValidator>();
+        services.AddScoped<IValidator<DTOs.EvaluationRequest>, EvaluationRequestValidator>();
+
         // Strategies — Singleton: stateless, safe to share across requests
         services.AddSingleton<IRolloutStrategy, NoneStrategy>();
         services.AddSingleton<IRolloutStrategy, PercentageStrategy>();

--- a/FeatureFlag.Application/FeatureFlag.Application.csproj
+++ b/FeatureFlag.Application/FeatureFlag.Application.csproj
@@ -5,6 +5,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentValidation" Version="12.*" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
   </ItemGroup>
 

--- a/FeatureFlag.Application/Services/FeatureFlagService.cs
+++ b/FeatureFlag.Application/Services/FeatureFlagService.cs
@@ -37,17 +37,24 @@ public sealed class FeatureFlagService : IFeatureFlagService
         CancellationToken ct = default
     )
     {
-        var flag = await _repository.GetByNameAsync(flagName, context.Environment, ct);
+        // Sanitize evaluation inputs. RuleFor lambdas in validators do not mutate the DTO.
+        // UserId and UserRoles must be cleaned here to ensure consistent SHA256 hashing
+        // in PercentageStrategy and HashSet lookups in RoleStrategy.
+        var sanitizedContext = new FeatureEvaluationContext(
+            userId: Validators.InputSanitizer.Clean(context.UserId) ?? context.UserId,
+            userRoles: Validators.InputSanitizer.CleanCollection(context.UserRoles),
+            environment: context.Environment
+        );
 
-        if (flag is null)
-            throw new KeyNotFoundException(
-                $"Flag '{flagName}' not found in {context.Environment}."
+        var flag = await _repository.GetByNameAsync(flagName, sanitizedContext.Environment, ct)
+            ?? throw new KeyNotFoundException(
+                $"Flag '{flagName}' not found in {sanitizedContext.Environment}."
             );
 
         if (!flag.IsEnabled)
             return false;
 
-        return _evaluator.Evaluate(flag, context);
+        return _evaluator.Evaluate(flag, sanitizedContext);
     }
 
     public async Task<IReadOnlyList<FlagResponse>> GetAllFlagsAsync(
@@ -64,8 +71,11 @@ public sealed class FeatureFlagService : IFeatureFlagService
         CancellationToken ct = default
     )
     {
+        // Sanitize Name so the stored value matches the validated form.
+        var sanitizedName = Validators.InputSanitizer.Clean(request.Name) ?? request.Name;
+
         var flag = new Flag(
-            request.Name,
+            sanitizedName,
             request.Environment,
             request.IsEnabled,
             request.StrategyType,

--- a/FeatureFlag.Application/Validators/CreateFlagRequestValidator.cs
+++ b/FeatureFlag.Application/Validators/CreateFlagRequestValidator.cs
@@ -1,0 +1,86 @@
+using FeatureFlag.Application.DTOs;
+using FeatureFlag.Domain.Enums;
+using FluentValidation;
+
+namespace FeatureFlag.Application.Validators;
+
+public sealed class CreateFlagRequestValidator : AbstractValidator<CreateFlagRequest>
+{
+    public CreateFlagRequestValidator()
+    {
+        // Validate the raw property for emptiness and length.
+        // Regex runs on the cleaned value — accepts padded input like " dark-mode "
+        // which the service layer will sanitize to "dark-mode" before storing.
+        RuleFor(x => x.Name)
+            .NotEmpty().WithMessage("Flag name is required.")
+            .MaximumLength(100).WithMessage("Flag name must not exceed 100 characters.")
+            .Must(name => System.Text.RegularExpressions.Regex.IsMatch(
+                InputSanitizer.Clean(name) ?? string.Empty, @"^[a-zA-Z0-9\-_]+$"))
+            .WithMessage("Flag name may only contain letters, numbers, hyphens, and underscores.");
+
+        RuleFor(x => x.Environment)
+            .NotEqual(EnvironmentType.None)
+            .WithMessage("A valid environment must be specified (Development, Staging, or Production).");
+
+        RuleFor(x => x.StrategyType)
+            .IsInEnum()
+            .WithMessage("StrategyType must be a valid value (None, Percentage, or RoleBased).");
+
+        // StrategyConfig: enforce size limit first, then cross-field structure rules.
+        // Note: StrategyConfig is NOT sanitized — it is JSON and must be stored verbatim.
+        // Only its length and internal structure are validated.
+        RuleFor(x => x.StrategyConfig)
+            .MaximumLength(2000)
+            .WithMessage("StrategyConfig must not exceed 2000 characters.");
+
+        // When strategy is None, StrategyConfig must be null or empty
+        RuleFor(x => x.StrategyConfig)
+            .Empty()
+            .When(x => x.StrategyType == RolloutStrategy.None)
+            .WithMessage("StrategyConfig must be empty when StrategyType is None.");
+
+        // When strategy is Percentage, config must contain a 'percentage' field (1–100)
+        RuleFor(x => x.StrategyConfig)
+            .NotEmpty().WithMessage("StrategyConfig is required for Percentage strategy.")
+            .Must(BeValidPercentageConfig)
+            .WithMessage(
+                "StrategyConfig for Percentage strategy must be valid JSON with " +
+                "a 'percentage' field between 1 and 100.")
+            .When(x => x.StrategyType == RolloutStrategy.Percentage);
+
+        // When strategy is RoleBased, config must contain a non-empty 'roles' array
+        RuleFor(x => x.StrategyConfig)
+            .NotEmpty().WithMessage("StrategyConfig is required for RoleBased strategy.")
+            .Must(BeValidRoleConfig)
+            .WithMessage(
+                "StrategyConfig for RoleBased strategy must be valid JSON with " +
+                "a non-empty 'roles' array.")
+            .When(x => x.StrategyType == RolloutStrategy.RoleBased);
+    }
+
+    private static bool BeValidPercentageConfig(string? config)
+    {
+        if (string.IsNullOrWhiteSpace(config)) return false;
+        try
+        {
+            var doc = System.Text.Json.JsonDocument.Parse(config);
+            if (!doc.RootElement.TryGetProperty("percentage", out var prop)) return false;
+            if (!prop.TryGetInt32(out var percentage)) return false;
+            return percentage >= 1 && percentage <= 100;
+        }
+        catch (System.Text.Json.JsonException) { return false; }
+    }
+
+    private static bool BeValidRoleConfig(string? config)
+    {
+        if (string.IsNullOrWhiteSpace(config)) return false;
+        try
+        {
+            var doc = System.Text.Json.JsonDocument.Parse(config);
+            if (!doc.RootElement.TryGetProperty("roles", out var prop)) return false;
+            if (prop.ValueKind != System.Text.Json.JsonValueKind.Array) return false;
+            return prop.GetArrayLength() > 0;
+        }
+        catch (System.Text.Json.JsonException) { return false; }
+    }
+}

--- a/FeatureFlag.Application/Validators/EvaluationRequestValidator.cs
+++ b/FeatureFlag.Application/Validators/EvaluationRequestValidator.cs
@@ -1,0 +1,40 @@
+using FeatureFlag.Application.DTOs;
+using FeatureFlag.Domain.Enums;
+using FluentValidation;
+
+namespace FeatureFlag.Application.Validators;
+
+public sealed class EvaluationRequestValidator : AbstractValidator<EvaluationRequest>
+{
+    public EvaluationRequestValidator()
+    {
+        RuleFor(x => x.FlagName)
+            .NotEmpty().WithMessage("FlagName is required.")
+            .MaximumLength(100).WithMessage("FlagName must not exceed 100 characters.");
+
+        RuleFor(x => x.UserId)
+            .NotEmpty().WithMessage("UserId is required.")
+            .MaximumLength(256).WithMessage("UserId must not exceed 256 characters.");
+
+        RuleFor(x => x.Environment)
+            .NotEqual(EnvironmentType.None)
+            .WithMessage("A valid environment must be specified (Development, Staging, or Production).");
+
+        // UserRoles: not null, max 50 entries, each role max 100 chars after sanitization
+        RuleFor(x => x.UserRoles)
+            .NotNull()
+            .WithMessage("UserRoles must not be null. Pass an empty array if the user has no roles.");
+
+        // .Take(51).Count() > 50 short-circuits at 51 — avoids enumerating the full collection
+        RuleFor(x => x.UserRoles)
+            .Must(roles => roles.Take(51).Count() <= 50)
+            .WithMessage("UserRoles must not exceed 50 entries.")
+            .When(x => x.UserRoles is not null);
+
+        // Validate cleaned length per role — consistent with service-layer sanitization behavior
+        RuleForEach(x => x.UserRoles)
+            .Must(role => (InputSanitizer.Clean(role)?.Length ?? 0) <= 100)
+            .WithMessage("Each role must not exceed 100 characters.")
+            .When(x => x.UserRoles is not null);
+    }
+}

--- a/FeatureFlag.Application/Validators/InputSanitizer.cs
+++ b/FeatureFlag.Application/Validators/InputSanitizer.cs
@@ -1,0 +1,42 @@
+namespace FeatureFlag.Application.Validators;
+
+/// <summary>
+/// Shared input sanitization helper.
+/// Called by validators (via RuleFor lambdas) and by the service layer before
+/// string values are used in evaluation logic.
+///
+/// Sanitizes for the HTTP boundary only. Does not substitute for prompt
+/// sanitization (Phase 1.5: IPromptSanitizer) or structured logging conventions.
+/// </summary>
+internal static class InputSanitizer
+{
+    /// <summary>
+    /// Trims leading/trailing whitespace and removes ASCII control characters
+    /// (codepoints below 0x20, except tab). Returns null if input is null.
+    /// </summary>
+    internal static string? Clean(string? value)
+    {
+        if (value is null) return null;
+
+        // Strip control characters (0x00–0x1F) except tab (0x09)
+        var cleaned = new string(value
+            .Where(c => c == '\t' || c >= 0x20)
+            .ToArray());
+
+        return cleaned.Trim();
+    }
+
+    /// <summary>
+    /// Applies Clean() to each element. Removes entries that are null or
+    /// empty after cleaning.
+    /// </summary>
+    internal static IEnumerable<string> CleanCollection(IEnumerable<string>? values)
+    {
+        if (values is null) return [];
+
+        return values
+            .Select(Clean)
+            .Where(v => !string.IsNullOrEmpty(v))
+            .Cast<string>();
+    }
+}

--- a/FeatureFlag.Application/Validators/UpdateFlagRequestValidator.cs
+++ b/FeatureFlag.Application/Validators/UpdateFlagRequestValidator.cs
@@ -1,0 +1,70 @@
+using FeatureFlag.Application.DTOs;
+using FeatureFlag.Domain.Enums;
+using FluentValidation;
+
+namespace FeatureFlag.Application.Validators;
+
+public sealed class UpdateFlagRequestValidator : AbstractValidator<UpdateFlagRequest>
+{
+    public UpdateFlagRequestValidator()
+    {
+        RuleFor(x => x.StrategyType)
+            .IsInEnum()
+            .WithMessage("StrategyType must be a valid value (None, Percentage, or RoleBased).");
+
+        // StrategyConfig: size limit first, then cross-field rules
+        RuleFor(x => x.StrategyConfig)
+            .MaximumLength(2000)
+            .WithMessage("StrategyConfig must not exceed 2000 characters.");
+
+        // When strategy is None, StrategyConfig must be null or empty
+        RuleFor(x => x.StrategyConfig)
+            .Empty()
+            .When(x => x.StrategyType == RolloutStrategy.None)
+            .WithMessage("StrategyConfig must be empty when StrategyType is None.");
+
+        // When strategy is Percentage, config must contain a 'percentage' field (1–100)
+        RuleFor(x => x.StrategyConfig)
+            .NotEmpty().WithMessage("StrategyConfig is required for Percentage strategy.")
+            .Must(BeValidPercentageConfig)
+            .WithMessage(
+                "StrategyConfig for Percentage strategy must be valid JSON with " +
+                "a 'percentage' field between 1 and 100.")
+            .When(x => x.StrategyType == RolloutStrategy.Percentage);
+
+        // When strategy is RoleBased, config must contain a non-empty 'roles' array
+        RuleFor(x => x.StrategyConfig)
+            .NotEmpty().WithMessage("StrategyConfig is required for RoleBased strategy.")
+            .Must(BeValidRoleConfig)
+            .WithMessage(
+                "StrategyConfig for RoleBased strategy must be valid JSON with " +
+                "a non-empty 'roles' array.")
+            .When(x => x.StrategyType == RolloutStrategy.RoleBased);
+    }
+
+    private static bool BeValidPercentageConfig(string? config)
+    {
+        if (string.IsNullOrWhiteSpace(config)) return false;
+        try
+        {
+            var doc = System.Text.Json.JsonDocument.Parse(config);
+            if (!doc.RootElement.TryGetProperty("percentage", out var prop)) return false;
+            if (!prop.TryGetInt32(out var percentage)) return false;
+            return percentage >= 1 && percentage <= 100;
+        }
+        catch (System.Text.Json.JsonException) { return false; }
+    }
+
+    private static bool BeValidRoleConfig(string? config)
+    {
+        if (string.IsNullOrWhiteSpace(config)) return false;
+        try
+        {
+            var doc = System.Text.Json.JsonDocument.Parse(config);
+            if (!doc.RootElement.TryGetProperty("roles", out var prop)) return false;
+            if (prop.ValueKind != System.Text.Json.JsonValueKind.Array) return false;
+            return prop.GetArrayLength() > 0;
+        }
+        catch (System.Text.Json.JsonException) { return false; }
+    }
+}

--- a/claude.md
+++ b/claude.md
@@ -1,72 +1,142 @@
 # CLAUDE.md — Project Instructions
 
-## Project Context
+## 1. Required Context
 
-Read the following docs at the start of every session before making any suggestions or writing any code:
+At the start of each session, read:
 
-- `docs/roadmap.md` — project roadmap and milestones
-- `docs/architecture.md` — system design and architectural decisions
-- `docs/instructions.md` — additional project-specific instructions
+- `Docs/roadmap.md`
+- `Docs/architecture.md`
+- `Docs/current-state.md`
+- Relevant spec in `Docs/Decisions/**/spec.md` (if working on a feature)
 
----
-
-## About Me
-
-I am a backend-focused .NET developer (C#, ASP.NET Core, Web APIs, SQL Server) returning to the industry and using this time to build strong, portfolio-worthy projects.
-
-My goals:
-- Produce real-world, production-quality work that demonstrates clean architecture, scalability, and best practices
-- Become a knowledge expert in .NET APIs, API design and security, developer tooling, and AI integration
-- Eventually layer in Salesforce development (Apex, SOQL, Flows, integrations) — treat it as a future workstream, not a current priority
+Do not proceed without this context.
 
 ---
 
-## About You
+## 2. Role
 
-You are a Senior-Level Software Engineer in the .Net Ecosystem. Your specialties are these: Prompt Engineering (you are always looking for ways to help the one you mentor to communicate with you better), API/System Design (something I'm most interested in), Docker, AI-Integration into dev workflows, Claude, and most importantly, C#/.Net. Your role is to help me write good clean code and understand what it is that I'm building. I want you to prepare me for interviews as we code. And I'm not afraid to deep-dive into some of the more stranger aspects of the language and framework. I want to understand .Net at a deep level.
+Act as a senior .NET backend engineer focused on:
 
-You will be given a spec document every time we work on this project which you will analyze. I'm using a different Claude instance to serve as my System Architect/Product Owner. You will implement. Always analyze the spec doc for implementation decisions. When finished, you will create <feature-branch-name>-implementation.md file which you will store in the /docs/decisions folder. Use evaluation-engine-implementation.md as an example.
+- Clean Architecture
+- API/System Design
+- Maintainable, production-quality code
+- AI Dev Workflows
+- Cloud Development and Deployment
 
----
-
-## How You Should Work With Me
-
-**Code quality:**
-- Always write clean, maintainable, production-grade code — no quick hacks
-- Default to .NET best practices: SOLID principles, Clean Architecture, dependency injection, proper layer separation
-- Always reference the latest .NET documentation and patterns (.NET 10)
-- When I ask for code, include structure (folder layout, project organization, naming conventions) — not just isolated snippets
-
-**Mentorship:**
-- You are my senior engineering partner, not just a code generator
-- Explain the *why* behind decisions briefly but clearly — assume I'm a junior to mid-level engineer.
-- Challenge weak design decisions and propose better alternatives with reasoning
-- When relevant, suggest improvements that strengthen the project professionally: testing, logging, observability, CI/CD, cloud readiness
-
-**Interview mindset:**
-- After we finish a meaningful feature or solve a non-trivial problem, briefly note how it could surface in a technical interview and what a strong answer looks like
-- Periodically ask probing questions like:
-  - "How would you explain this decision to a senior engineer on your team?"
-  - "What are the trade-offs we accepted here?"
-  - "How does this hold up if the requirements change?"
-  - "What would you add before shipping this to production?"
-
-**Salesforce:**
-- When contextually relevant, connect .NET work to Salesforce patterns (REST/SOAP integrations, data sync, event-driven flows, external services)
-- Treat this as a value-add lens, not a core focus — for now
+Your responsibility is to:
+- Analyze the specs, check for issues
+- Refer to the most current Microsoft C#/.Net documentation when making suggestions
+- Implement features from specs
+- Improve design quality
+- Help the developer think at a senior level
 
 ---
 
-## Project Mindset
+## 3. Execution Workflow (Always Follow)
 
-- Treat every piece of work as if it will be reviewed in a real job interview
-- Optimize for clarity, scalability, and professionalism over speed
-- Help me think like a senior engineer — not just complete tasks
+### When given a feature, bug, or refactor:
+
+1. **Understand**
+   - Summarize requirements
+   - Identify missing or ambiguous details
+   - Check current documentation for breaking changes or deprecated features
+
+2. **Validate**
+   - Ask clarifying questions if needed
+   - Confirm assumptions before coding
+
+3. **Design**
+   - Identify affected layers (Domain, Application, Infrastructure, API)
+   - Define interfaces and contracts
+   - Highlight trade-offs if relevant
+
+4. **Implement**
+   - Write clean, production-ready code
+   - Follow .NET best practices and project architecture
+
+5. **Verify**
+   - Suggest or include tests
+   - Ensure no architectural violations
+
+6. **Document**
+   - Create `implementation-notes.md` in `/Docs/Decisions/<spec-name>/`. I will have already created the folder.
+   - Include key decisions and reasoning
 
 ---
 
-## Before You Proceed
+## 4. Spec-Driven Development (Critical)
 
-- If a request is ambiguous or underspecified, ask clarifying questions before writing code or making architectural decisions.
-- When provided with the Requirements List for the new feature, refactor, or debug session, review those requirements and ask clarify questions. 
-- I would also like to use this opportunity to learn to communicate with you better (Prompt Engineering)
+When a `spec.md` is provided:
+
+- Extract:
+  - Requirements
+  - Constraints
+  - Edge cases
+
+- Do NOT:
+  - Skip unclear requirements
+  - Invent behavior without stating assumptions
+
+- Always:
+  - Align implementation strictly to spec
+  - Call out gaps or inconsistencies
+
+---
+
+## 5. Coding Standards
+
+- Follow SOLID and Clean Architecture
+- No business logic in controllers
+- No direct DB access outside Infrastructure
+- Use dependency injection
+- Prefer small, focused classes
+
+---
+
+## 6. Output Expectations
+
+For non-trivial work, structure responses as:
+
+### 1. Summary
+Brief explanation of approach
+
+### 2. Design
+Key decisions and architecture
+
+### 3. Implementation
+Code with proper structure
+
+### 4. Notes
+Trade-offs, improvements, or concerns
+
+Be concise but complete.
+
+---
+
+## 7. Mentorship Mode
+
+- Explain *why* behind decisions (briefly)
+- Challenge weak designs
+- Suggest improvements when relevant:
+  - testing
+  - logging
+  - observability
+  - performance
+
+---
+
+## 8. Interview Lens
+
+When completing meaningful work:
+
+- Highlight how this could appear in an interview
+- Provide a strong, concise explanation
+
+---
+
+## 9. When Uncertain
+
+- Ask clarifying questions OR
+- State assumptions clearly before proceeding
+
+Do not guess silently.


### PR DESCRIPTION
## Summary

- Adds `InputSanitizer` — shared static helper that trims whitespace and strips control
  characters; called by validators and service layer
- Adds `CreateFlagRequestValidator`, `UpdateFlagRequestValidator`,
  `EvaluationRequestValidator` — manual `IValidator<T>` injection in controllers
- `FeatureFlagService` sanitizes `Name` on create and evaluation context before use
- Closes KI-003 (StrategyConfig validation at write time)
- Also includes `claude.md` rewrite and `current-state.md` updates

## Deviations from spec (accepted by architect)

- `AddValidatorsFromAssemblyContaining` replaced with explicit `AddScoped` registrations
  (requires a separate package not bundled in core)
- Sanitization-aware rules use `Must()` instead of `RuleFor(x => Clean(x.Prop))`
  due to v12 type inference limitation — same runtime behavior

## Test plan

- [ ] Build passes: 0 warnings, 0 errors
- [ ] All 8 existing tests pass
- [ ] POST /api/flags with empty Name → 400 ValidationProblemDetails
- [ ] POST /api/flags with padded Name `" dark-mode "` → 201, stored as `"dark-mode"`
- [ ] POST /api/evaluate with whitespace UserId → same result as trimmed UserId
- [ ] POST /api/evaluate with null UserRoles → 400
- [ ] POST /api/flags with StrategyType Percentage + missing config → 400