### PR TITLE
feat: global exception middleware and domain exception hierarchy 

### DIFF
--- a/.github/prompts/ai-review-system.md
+++ b/.github/prompts/ai-review-system.md
@@ -24,9 +24,11 @@ Rules to enforce:
    repository calls and external service calls.
 7. Evaluation logic must remain deterministic and isolated from persistence.
    Do not suggest mixing evaluation logic with repository calls.
-8. A global exception middleware is being added in Phase 1 (it may not yet be present in
-   the codebase). Until it is confirmed in place: do not add new try/catch blocks in
-   controllers, and do not flag existing try/catch blocks as violations.
+8. `GlobalExceptionMiddleware` is registered as the first middleware in `Program.cs` and
+   handles all unhandled exceptions. Controllers must contain only the happy path — no
+   try/catch blocks. Flag any try/catch in a controller as an error. Domain exceptions
+   (`FeatureFlagException` subclasses) are thrown by the service layer and caught by the
+   middleware; controllers must not catch them.
 9. Naming conventions: interfaces prefixed with `I`, async methods suffixed with `Async`,
    no abbreviations in public member names.
 10. Zero warnings policy: do not suggest suppressing warnings with `#pragma warning disable`

--- a/Docs/Decisions/spec-global-exception-handling - PR#36/implementation-notes.md
+++ b/Docs/Decisions/spec-global-exception-handling - PR#36/implementation-notes.md
@@ -1,0 +1,122 @@
+# Global Exception Handling — Implementation Notes
+
+**Session date:** 2026-04-01
+**Branch:** `feature/error-handling`
+**Spec reference:** `Docs/Decisions/spec-global-exception-handling - PR#36/spec.md`
+**Build status:** Passed — 0 warnings, 0 errors
+**Tests:** 8/8 passing
+**PR:** #36
+
+---
+
+## Table of Contents
+
+- [What Was Built](#what-was-built)
+- [Spec Gaps Resolved](#spec-gaps-resolved)
+- [Deviations from Spec](#deviations-from-spec)
+- [File-by-File Changes](#file-by-file-changes)
+- [Definition of Done — Status](#definition-of-done--status)
+- [AI Reviewer System Prompt](#ai-reviewer-system-prompt)
+
+---
+
+## What Was Built
+
+A domain exception hierarchy, global exception middleware, and controller cleanup
+that replaces all per-controller `try/catch` blocks. Every error response now uses
+a consistent `ProblemDetails` shape.
+
+---
+
+## Spec Gaps Resolved
+
+### Gap 1 — `IsEnabledAsync` omitted from AC-6
+
+AC-6 listed three methods to update (`GetFlagAsync`, `UpdateFlagAsync`,
+`ArchiveFlagAsync`) but `IsEnabledAsync` also threw `KeyNotFoundException` on a
+null flag lookup. The DoD item `POST /api/evaluate` returns `ProblemDetails` 404
+confirmed the intent. `IsEnabledAsync` was updated to throw `FlagNotFoundException`
+along with the other three methods.
+
+### Gap 2 — Content-Type should be `application/problem+json`
+
+The spec specified `MediaTypeNames.Application.Json` (`"application/json"`) but
+the DoD claims RFC 9457 compliance. RFC 9457 §8.1 requires `application/problem+json`
+for problem details responses. ASP.NET Core's own `ValidationProblem()` path also
+returns `application/problem+json`. Using `"application/json"` would create
+inconsistency. Confirmed with developer and updated to `"application/problem+json"`.
+
+---
+
+## Deviations from Spec
+
+### `JsonSerializerOptions` cached as `static readonly`
+
+The spec's `WriteProblemDetailsAsync` snippet created `new JsonSerializerOptions`
+on every invocation. `JsonSerializerOptions` construction is expensive (builds
+internal metadata caches) and is a known .NET performance anti-pattern when
+allocated per-call. Changed to a `static readonly` field on the middleware class.
+This is strictly correct — no behavioural change.
+
+---
+
+## File-by-File Changes
+
+### New files
+
+| File | Purpose |
+|---|---|
+| `FeatureFlag.Domain/Exceptions/FeatureFlagException.cs` | Abstract base — carries `StatusCode`, no ASP.NET Core reference |
+| `FeatureFlag.Domain/Exceptions/FlagNotFoundException.cs` | 404 — thrown on null flag lookup |
+| `FeatureFlag.Domain/Exceptions/DuplicateFlagNameException.cs` | 409 — defined, not yet thrown (name uniqueness is a separate task) |
+| `FeatureFlag.Api/Middleware/GlobalExceptionMiddleware.cs` | Single catch-all handler — domain exceptions → named 4xx, everything else → safe 500 |
+
+### Modified files
+
+| File | Change |
+|---|---|
+| `FeatureFlag.Domain/FeatureFlag.Domain.csproj` | Added `<FrameworkReference Include="Microsoft.AspNetCore.App" />` for `StatusCodes` constants |
+| `FeatureFlag.Api/Program.cs` | `app.UseMiddleware<GlobalExceptionMiddleware>()` registered first in pipeline |
+| `FeatureFlag.Application/Services/FeatureFlagService.cs` | All four `KeyNotFoundException` throws replaced with `FlagNotFoundException`; added `using FeatureFlag.Domain.Exceptions` |
+| `FeatureFlag.Api/Controllers/FeatureFlagsController.cs` | Removed `try/catch` from `GetByNameAsync`, `UpdateAsync`, `ArchiveAsync` |
+| `FeatureFlag.Api/Controllers/EvaluationController.cs` | Removed `try/catch` from `EvaluateAsync`; removed `e.Message` from error response |
+
+---
+
+## Definition of Done — Status
+
+- [x] `FeatureFlag.Domain/Exceptions/` folder created with all three exception classes
+- [x] `FrameworkReference` added to `FeatureFlag.Domain.csproj`
+- [x] `GlobalExceptionMiddleware` created in `FeatureFlag.Api/Middleware/`
+- [x] Middleware registered first in `Program.cs`
+- [x] `FeatureFlagService` throws `FlagNotFoundException` — no `KeyNotFoundException` references remain in Application
+- [x] `FeatureFlagsController` has zero `try/catch` blocks
+- [x] `EvaluationController` has zero `try/catch` blocks
+- [ ] `GET /api/flags/{name}` with unknown name returns `ProblemDetails` 404 — verified by integration test (Phase 2)
+- [ ] `PUT /api/flags/{name}` with unknown name returns `ProblemDetails` 404 — verified by integration test (Phase 2)
+- [ ] `DELETE /api/flags/{name}` with unknown name returns `ProblemDetails` 404 — verified by integration test (Phase 2)
+- [ ] `POST /api/evaluate` with unknown flag name returns `ProblemDetails` 404 — verified by integration test (Phase 2)
+- [ ] An unhandled `Exception` returns `ProblemDetails` 500 with safe detail message — verified by integration test (Phase 2)
+- [ ] `LogError` fires for the 500 path with full exception details — verified by integration test (Phase 2)
+- [x] `ProblemDetails` responses include `instance` set to the request path
+- [x] `Content-Type: application/problem+json` on all error responses
+- [x] `dotnet build FeatureFlagService.sln` → 0 errors, 0 warnings
+- [x] All existing tests passing: `dotnet test --filter "Category!=Integration"` → 8/8
+- [x] CSharpier: `dotnet csharpier check .` → 0 violations
+
+The four DoD items marked incomplete require a running Postgres instance and are
+integration-test concerns — they will be closed in Phase 2.
+
+---
+
+## AI Reviewer System Prompt
+
+Per `current-state.md` and `roadmap.md`: Rule 8 in
+`.github/prompts/ai-review-system.md` currently tells the reviewer that
+controllers use `try/catch` for error handling. Now that global exception
+middleware is in place, Rule 8 must be updated to reflect that controllers
+contain only the happy path and `GlobalExceptionMiddleware` handles all exceptions.
+
+Rule 8 was updated in this PR. It now states that `GlobalExceptionMiddleware` is in
+place, controllers must contain only the happy path, and any `try/catch` in a
+controller is a reviewable error.

--- a/Docs/Decisions/spec-global-exception-handling - PR#36/spec.md
+++ b/Docs/Decisions/spec-global-exception-handling - PR#36/spec.md
@@ -1,0 +1,551 @@
+
+# Global Exception Handling — Spec
+
+**Document:** `Docs/Decisions/spec-global-exception-handling - PR#36/spec.md`
+**Branch:** `feature/error-handling`
+**Phase:** 1 — Error Handling
+**Status:** Ready for Implementation
+**PR:** #36
+**Author:** Joe / Claude Architect Session
+**Date:** 2026-04-01
+
+---
+
+## Table of Contents
+
+- [User Story](#user-story)
+- [Background and Goals](#background-and-goals)
+- [Design Decisions](#design-decisions)
+- [Scope](#scope)
+- [Exception Hierarchy](#exception-hierarchy)
+  - [AC-1 FeatureFlagException — Base Class](#ac-1-featureflagexception--base-class)
+  - [AC-2 FlagNotFoundException](#ac-2-flagnotfoundexception)
+  - [AC-3 DuplicateFlagNameException](#ac-3-duplicateflagnamexception)
+- [Middleware](#middleware)
+  - [AC-4 GlobalExceptionMiddleware](#ac-4-globalexceptionmiddleware)
+  - [AC-5 Middleware Registration](#ac-5-middleware-registration)
+- [Service Layer Updates](#service-layer-updates)
+  - [AC-6 Throw Instead of Return Null](#ac-6-throw-instead-of-return-null)
+- [Controller Cleanup](#controller-cleanup)
+  - [AC-7 Remove try/catch From All Controllers](#ac-7-remove-trycatch-from-all-controllers)
+- [File Layout](#file-layout)
+- [Implementation Notes](#implementation-notes)
+- [Out of Scope](#out-of-scope)
+- [Definition of Done](#definition-of-done)
+
+---
+
+## User Story
+
+> As a developer integrating with FeatureFlagService, I want every error response
+> to have a consistent, predictable shape — so I can handle failures reliably
+> without inspecting each endpoint individually.
+
+---
+
+## Background and Goals
+
+Every controller action currently wraps its logic in a `try/catch` block. This
+creates three problems:
+
+1. **Repetition.** Error handling is a cross-cutting concern — it should live in
+   one place, not six.
+2. **Inconsistent error shape.** Some endpoints return `NotFound()` with no body.
+   Others return `NotFound(new { error = message })`. Consumers cannot rely on a
+   predictable structure.
+3. **Raw system exceptions leak through.** `KeyNotFoundException` is a .NET
+   runtime exception with no semantic meaning to an API consumer.
+
+This spec replaces all of the above with:
+
+- A **domain exception hierarchy** in `FeatureFlag.Domain` that gives every
+  failure mode an explicit name and HTTP status code.
+- A **single `GlobalExceptionMiddleware`** in `FeatureFlag.Api` that catches
+  everything, maps domain exceptions to `ProblemDetails`, logs unexpected
+  errors, and returns a safe `500` for anything else.
+- **Controllers with no error handling** — they contain only the happy path.
+
+---
+
+## Design Decisions
+
+### Why domain exceptions in `FeatureFlag.Domain` and not `FeatureFlag.Application`?
+
+Domain is the innermost layer. Every other layer already references it. Placing
+exceptions here means `Application`, `Infrastructure`, and `Api` can all throw
+and catch them with zero new project references. A `FlagNotFoundException` is a
+domain concept — it represents a business fact ("this flag does not exist"), not
+an infrastructure or orchestration detail.
+
+### Why custom exception types instead of a switch on error codes?
+
+Named exceptions are explicit and self-documenting. Adding a new failure mode
+means adding a new class — the middleware never changes. This follows the
+Open/Closed Principle: open for extension, closed for modification.
+
+### Why middleware instead of `IExceptionFilter`?
+
+An exception filter only activates if the request successfully reached the MVC
+pipeline. Middleware wraps the entire HTTP pipeline — it catches errors from
+routing, other middleware, and MVC alike. For a global handler, middleware is
+the correct tool.
+
+### Why `ProblemDetails` (RFC 9457)?
+
+`ProblemDetails` is an IETF internet standard for HTTP error responses. ASP.NET
+Core has first-class support for it. Consumers get a consistent, documented shape
+they can parse reliably across all endpoints.
+
+### Why `about:blank` for the `Type` field?
+
+RFC 9457 recommends `about:blank` for standard HTTP errors with no additional
+domain-specific semantics. It requires zero maintenance — no RFC section numbers
+to track or get wrong. Custom URIs pointing to FeatureFlagService documentation
+will be introduced in Phase 1.5 for domain-specific error types.
+
+### Why `StatusCodes` constants instead of magic numbers?
+
+`Microsoft.AspNetCore.Http.StatusCodes` provides named constants
+(`Status404NotFound`, `Status409Conflict`) that carry both the numeric value and
+its semantic meaning. Magic numbers like `404` scattered through the codebase
+require the reader to know HTTP to understand the code. The Domain project adds a
+`FrameworkReference` to `Microsoft.AspNetCore.App` to support this — a pragmatic
+and intentional trade-off documented here.
+
+---
+
+## Scope
+
+| # | What | File(s) |
+|---|---|---|
+| 1 | `FeatureFlagException` base class | `Domain/Exceptions/FeatureFlagException.cs` |
+| 2 | `FlagNotFoundException` | `Domain/Exceptions/FlagNotFoundException.cs` |
+| 3 | `DuplicateFlagNameException` | `Domain/Exceptions/DuplicateFlagNameException.cs` |
+| 4 | `GlobalExceptionMiddleware` | `Api/Middleware/GlobalExceptionMiddleware.cs` |
+| 5 | Middleware registration | `Api/Program.cs` |
+| 6 | Service layer — throw instead of return null | `Application/Services/FeatureFlagService.cs` |
+| 7 | Controller cleanup — remove all try/catch | `Api/Controllers/FeatureFlagsController.cs`, `Api/Controllers/EvaluationController.cs` |
+
+---
+
+## Exception Hierarchy
+
+### AC-1: `FeatureFlagException` — Base Class
+
+**File:** `FeatureFlag.Domain/Exceptions/FeatureFlagException.cs`
+
+```csharp
+namespace FeatureFlag.Domain.Exceptions;
+
+/// 
+
+/// Base class for all domain exceptions in FeatureFlagService.
+/// Carries the HTTP status code that the middleware will use
+/// when building the ProblemDetails response.
+/// 
+
+public abstract class FeatureFlagException : Exception
+{
+    /// 
+
+    /// The HTTP status code this exception maps to.
+    /// 
+
+    public int StatusCode { get; }
+
+    protected FeatureFlagException(string message, int statusCode)
+        : base(message)
+    {
+        StatusCode = statusCode;
+    }
+}
+```
+
+**Rules:**
+- `abstract` — never instantiated directly, only through concrete subclasses
+- `StatusCode` is read-only, set once at construction
+- No ASP.NET Core references on the base class — only on the subclasses
+
+---
+
+### AC-2: `FlagNotFoundException`
+
+**File:** `FeatureFlag.Domain/Exceptions/FlagNotFoundException.cs`
+
+```csharp
+using Microsoft.AspNetCore.Http;
+
+namespace FeatureFlag.Domain.Exceptions;
+
+/// 
+
+/// Thrown when a feature flag cannot be found by name and environment.
+/// Maps to HTTP 404 Not Found.
+/// 
+
+public sealed class FlagNotFoundException : FeatureFlagException
+{
+    public FlagNotFoundException(string flagName)
+        : base(
+            $"No feature flag with name '{flagName}' was found.",
+            StatusCodes.Status404NotFound)
+    {
+    }
+}
+```
+
+**Rules:**
+- `sealed` — not intended for further subclassing
+- Message format is fixed — consistent across all callers
+
+---
+
+### AC-3: `DuplicateFlagNameException`
+
+**File:** `FeatureFlag.Domain/Exceptions/DuplicateFlagNameException.cs`
+
+```csharp
+using Microsoft.AspNetCore.Http;
+
+namespace FeatureFlag.Domain.Exceptions;
+
+/// 
+
+/// Thrown when a flag creation attempt conflicts with an existing flag
+/// of the same name in the same environment.
+/// Maps to HTTP 409 Conflict.
+/// 
+
+public sealed class DuplicateFlagNameException : FeatureFlagException
+{
+    public DuplicateFlagNameException(string flagName)
+        : base(
+            $"A feature flag with name '{flagName}' already exists in this environment.",
+            StatusCodes.Status409Conflict)
+    {
+    }
+}
+```
+
+**Rules:**
+- `sealed` — not intended for further subclassing
+- HTTP 409 Conflict is the correct status for a uniqueness collision
+
+> **Note for implementer:** `DuplicateFlagNameException` is defined here but not
+> yet thrown. The name uniqueness check in the service layer is a separate Phase 1
+> task. This exception is created now so the hierarchy is complete and the
+> middleware already handles it when that task lands.
+
+---
+
+## Middleware
+
+### AC-4: `GlobalExceptionMiddleware`
+
+**File:** `FeatureFlag.Api/Middleware/GlobalExceptionMiddleware.cs`
+
+```csharp
+using FeatureFlag.Domain.Exceptions;
+using Microsoft.AspNetCore.Mvc;
+using System.Net.Mime;
+using System.Text.Json;
+
+namespace FeatureFlag.Api.Middleware;
+
+/// 
+
+/// Catches all unhandled exceptions in the pipeline and returns a
+/// consistent ProblemDetails response. Domain exceptions are mapped
+/// to their declared HTTP status codes. All other exceptions are logged
+/// and returned as a generic 500.
+/// 
+
+public sealed class GlobalExceptionMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly ILogger<GlobalExceptionMiddleware> _logger;
+
+    public GlobalExceptionMiddleware(
+        RequestDelegate next,
+        ILogger<GlobalExceptionMiddleware> logger)
+    {
+        _next = next;
+        _logger = logger;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        try
+        {
+            await _next(context);
+        }
+        catch (FeatureFlagException ex)
+        {
+            await WriteProblemDetailsAsync(
+                context,
+                statusCode: ex.StatusCode,
+                title: GetTitleForStatusCode(ex.StatusCode),
+                detail: ex.Message);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                ex,
+                "Unhandled exception on {Method} {Path}",
+                context.Request.Method,
+                context.Request.Path);
+
+            await WriteProblemDetailsAsync(
+                context,
+                statusCode: StatusCodes.Status500InternalServerError,
+                title: "An unexpected error occurred.",
+                detail: "An internal error occurred. Please try again later.");
+        }
+    }
+
+    private static async Task WriteProblemDetailsAsync(
+        HttpContext context,
+        int statusCode,
+        string title,
+        string detail)
+    {
+        var problem = new ProblemDetails
+        {
+            // "about:blank" is the RFC 9457 recommendation for standard HTTP errors
+            // with no additional domain-specific semantics. No maintenance required.
+            // Custom URIs will be introduced in Phase 1.5 for domain-specific errors.
+            Type = "about:blank",
+            Title = title,
+            Status = statusCode,
+            Detail = detail,
+            Instance = context.Request.Path
+        };
+
+        context.Response.StatusCode = statusCode;
+        context.Response.ContentType = MediaTypeNames.Application.Json;
+
+        await context.Response.WriteAsync(
+            JsonSerializer.Serialize(
+                problem,
+                new JsonSerializerOptions
+                {
+                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+                }));
+    }
+
+    private static string GetTitleForStatusCode(int statusCode) =>
+        statusCode switch
+        {
+            StatusCodes.Status400BadRequest  => "Bad Request",
+            StatusCodes.Status404NotFound    => "Not Found",
+            StatusCodes.Status409Conflict    => "Conflict",
+            _                                => "An error occurred"
+        };
+}
+```
+
+**Rules:**
+- `FeatureFlagException` path: no logging — these are expected, named failures
+- `Exception` path: `LogError` with full exception — operators need the stack trace
+- The 500 `detail` string must never include `ex.Message` — information disclosure risk
+- `ProblemDetails.Instance` must be set to `context.Request.Path`
+- `Content-Type` must be `application/json` on all error responses
+
+---
+
+### AC-5: Middleware Registration
+
+**File:** `FeatureFlag.Api/Program.cs`
+
+Register `GlobalExceptionMiddleware` as the **first** middleware in the pipeline,
+before all other `Use*` calls.
+
+```csharp
+// Must be first — wraps the entire pipeline
+app.UseMiddleware<GlobalExceptionMiddleware>();
+
+// All other middleware follows
+app.UseHttpsRedirection();
+app.MapControllers();
+// etc.
+```
+
+---
+
+## Service Layer Updates
+
+### AC-6: Throw Instead of Return Null
+
+**File:** `FeatureFlag.Application/Services/FeatureFlagService.cs`
+
+Replace null returns and `KeyNotFoundException` handling with explicit
+`FlagNotFoundException` throws in the following methods:
+
+#### `GetFlagAsync`
+
+```csharp
+// Before
+var flag = await _repository.GetByNameAsync(name, environment, ct);
+if (flag is null) return null;
+return flag.ToResponse();
+
+// After
+var flag = await _repository.GetByNameAsync(name, environment, ct);
+if (flag is null)
+    throw new FlagNotFoundException(name);
+return flag.ToResponse();
+```
+
+#### `UpdateFlagAsync`
+
+```csharp
+// Before — try/catch KeyNotFoundException
+// After — remove try/catch, throw on null lookup
+var flag = await _repository.GetByNameAsync(name, environment, ct);
+if (flag is null)
+    throw new FlagNotFoundException(name);
+```
+
+#### `ArchiveFlagAsync`
+
+Same pattern as `UpdateFlagAsync`.
+
+**Rules:**
+- `using FeatureFlag.Domain.Exceptions;` added to the using block
+- No `try/catch` remains in `FeatureFlagService` after this change
+- `KeyNotFoundException` must not be thrown or caught anywhere in the Application layer
+
+---
+
+## Controller Cleanup
+
+### AC-7: Remove try/catch From All Controllers
+
+**Files:**
+- `FeatureFlag.Api/Controllers/FeatureFlagsController.cs`
+- `FeatureFlag.Api/Controllers/EvaluationController.cs`
+
+Every action method should contain only the happy path. Before and after:
+
+```csharp
+// Before
+public async Task<IActionResult> GetByNameAsync(...)
+{
+    try
+    {
+        var flag = await _service.GetFlagAsync(name, environment, ct);
+        return Ok(flag);
+    }
+    catch (KeyNotFoundException)
+    {
+        return NotFound();
+    }
+}
+
+// After
+public async Task<IActionResult> GetByNameAsync(...)
+{
+    var flag = await _service.GetFlagAsync(name, environment, ct);
+    return Ok(flag);
+}
+```
+
+Apply the same pattern to `Update`, `Archive`, and `Evaluate`.
+
+**Rules:**
+- Zero `try/catch` blocks remain in any controller after this change
+- Zero `catch (KeyNotFoundException)` references remain anywhere in `FeatureFlag.Api`
+- `return NotFound()` is removed from controllers
+- FluentValidation `ValidateAsync` calls and their `400` returns are **not** removed —
+  those are input validation, not exception handling, and belong in the controller
+
+---
+
+## File Layout
+
+```
+FeatureFlag.Domain/
+  Exceptions/
+    FeatureFlagException.cs          ← new
+    FlagNotFoundException.cs         ← new
+    DuplicateFlagNameException.cs    ← new
+
+FeatureFlag.Api/
+  Middleware/
+    GlobalExceptionMiddleware.cs     ← new
+  Program.cs                         ← modified (middleware registration)
+  Controllers/
+    FeatureFlagsController.cs        ← modified (remove try/catch)
+    EvaluationController.cs          ← modified (remove try/catch)
+
+FeatureFlag.Application/
+  Services/
+    FeatureFlagService.cs            ← modified (throw FlagNotFoundException)
+```
+
+---
+
+## Implementation Notes
+
+### `Microsoft.AspNetCore.Http` in Domain
+
+`FlagNotFoundException` and `DuplicateFlagNameException` reference
+`Microsoft.AspNetCore.Http.StatusCodes`. Add a framework reference to
+`FeatureFlag.Domain.csproj` if not already present:
+
+```xml
+<ItemGroup>
+  <FrameworkReference Include="Microsoft.AspNetCore.App" />
+</ItemGroup>
+```
+
+No additional NuGet package is required — this is a framework reference,
+not a package reference.
+
+### Build and Format Sequence
+
+Always run in this order:
+
+```bash
+dotnet build FeatureFlagService.sln
+dotnet test --filter "Category!=Integration"
+dotnet csharpier format .
+dotnet csharpier check .
+```
+
+CSharpier is the final formatting authority. Run `dotnet format` first if needed,
+then CSharpier.
+
+---
+
+## Out of Scope
+
+- `DuplicateFlagNameException` is **defined** here but not yet **thrown** —
+  the name uniqueness check is a separate task
+- `RouteParameterGuard` for KI-008 — separate task
+- Logging middleware for request/response tracing — Phase 4
+- `OperationCanceledException` handling — ASP.NET Core handles this natively
+- Structured logging configuration — Phase 1.5 (Application Insights)
+
+---
+
+## Definition of Done
+
+- [ ] `FeatureFlag.Domain/Exceptions/` folder created with all three exception classes
+- [ ] `FrameworkReference` added to `FeatureFlag.Domain.csproj`
+- [ ] `GlobalExceptionMiddleware` created in `FeatureFlag.Api/Middleware/`
+- [ ] Middleware registered first in `Program.cs`
+- [ ] `FeatureFlagService` throws `FlagNotFoundException` — no `KeyNotFoundException` references remain in Application
+- [ ] `FeatureFlagsController` has zero `try/catch` blocks
+- [ ] `EvaluationController` has zero `try/catch` blocks
+- [ ] `GET /api/flags/{name}` with unknown name returns `ProblemDetails` 404
+- [ ] `PUT /api/flags/{name}` with unknown name returns `ProblemDetails` 404
+- [ ] `DELETE /api/flags/{name}` with unknown name returns `ProblemDetails` 404
+- [ ] `POST /api/evaluate` with unknown flag name returns `ProblemDetails` 404
+- [ ] An unhandled `Exception` returns `ProblemDetails` 500 with safe detail message
+- [ ] `LogError` fires for the 500 path with full exception details
+- [ ] `ProblemDetails` responses include `instance` set to the request path
+- [ ] `Content-Type: application/json` on all error responses
+- [ ] `dotnet build FeatureFlagService.sln` → 0 errors, 0 warnings
+- [ ] All existing tests passing: `dotnet test --filter "Category!=Integration"`
+- [ ] CSharpier: `dotnet csharpier check .` → 0 violations

--- a/FeatureFlag.Api/Controllers/EvaluationController.cs
+++ b/FeatureFlag.Api/Controllers/EvaluationController.cs
@@ -57,20 +57,13 @@ public sealed class EvaluationController : ControllerBase
             return ValidationProblem(new ValidationProblemDetails(validation.ToDictionary()));
         }
 
-        try
-        {
-            var context = new FeatureEvaluationContext(
-                request.UserId,
-                request.UserRoles,
-                request.Environment
-            );
+        var context = new FeatureEvaluationContext(
+            request.UserId,
+            request.UserRoles,
+            request.Environment
+        );
 
-            bool isEnabled = await _service.IsEnabledAsync(request.FlagName, context, ct);
-            return Ok(new EvaluationResponse(isEnabled));
-        }
-        catch (KeyNotFoundException e)
-        {
-            return NotFound(new { error = e.Message });
-        }
+        bool isEnabled = await _service.IsEnabledAsync(request.FlagName, context, ct);
+        return Ok(new EvaluationResponse(isEnabled));
     }
 }

--- a/FeatureFlag.Api/Controllers/FeatureFlagsController.cs
+++ b/FeatureFlag.Api/Controllers/FeatureFlagsController.cs
@@ -69,15 +69,8 @@ public sealed class FeatureFlagsController : ControllerBase
         CancellationToken ct
     )
     {
-        try
-        {
-            FlagResponse flag = await _service.GetFlagAsync(name, environment, ct);
-            return Ok(flag);
-        }
-        catch (KeyNotFoundException)
-        {
-            return NotFound();
-        }
+        FlagResponse flag = await _service.GetFlagAsync(name, environment, ct);
+        return Ok(flag);
     }
 
     /// <summary>
@@ -151,15 +144,8 @@ public sealed class FeatureFlagsController : ControllerBase
             return ValidationProblem(new ValidationProblemDetails(validation.ToDictionary()));
         }
 
-        try
-        {
-            await _service.UpdateFlagAsync(name, environment, request, ct);
-            return NoContent();
-        }
-        catch (KeyNotFoundException)
-        {
-            return NotFound();
-        }
+        await _service.UpdateFlagAsync(name, environment, request, ct);
+        return NoContent();
     }
 
     /// <summary>
@@ -186,14 +172,7 @@ public sealed class FeatureFlagsController : ControllerBase
         CancellationToken ct
     )
     {
-        try
-        {
-            await _service.ArchiveFlagAsync(name, environment, ct);
-            return NoContent();
-        }
-        catch (KeyNotFoundException)
-        {
-            return NotFound();
-        }
+        await _service.ArchiveFlagAsync(name, environment, ct);
+        return NoContent();
     }
 }

--- a/FeatureFlag.Api/Middleware/GlobalExceptionMiddleware.cs
+++ b/FeatureFlag.Api/Middleware/GlobalExceptionMiddleware.cs
@@ -1,0 +1,98 @@
+using System.Text.Json;
+using FeatureFlag.Domain.Exceptions;
+using Microsoft.AspNetCore.Mvc;
+
+namespace FeatureFlag.Api.Middleware;
+
+/// <summary>
+/// Catches all unhandled exceptions in the pipeline and returns a
+/// consistent ProblemDetails response. Domain exceptions are mapped
+/// to their declared HTTP status codes. All other exceptions are logged
+/// and returned as a generic 500.
+/// </summary>
+public sealed class GlobalExceptionMiddleware
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    };
+
+    private readonly RequestDelegate _next;
+    private readonly ILogger<GlobalExceptionMiddleware> _logger;
+
+    public GlobalExceptionMiddleware(
+        RequestDelegate next,
+        ILogger<GlobalExceptionMiddleware> logger
+    )
+    {
+        _next = next;
+        _logger = logger;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        try
+        {
+            await _next(context);
+        }
+        catch (FeatureFlagException ex)
+        {
+            await WriteProblemDetailsAsync(
+                context,
+                statusCode: ex.StatusCode,
+                title: GetTitleForStatusCode(ex.StatusCode),
+                detail: ex.Message
+            );
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                ex,
+                "Unhandled exception on {Method} {Path}",
+                context.Request.Method,
+                context.Request.Path
+            );
+
+            await WriteProblemDetailsAsync(
+                context,
+                statusCode: StatusCodes.Status500InternalServerError,
+                title: "An unexpected error occurred.",
+                detail: "An internal error occurred. Please try again later."
+            );
+        }
+    }
+
+    private static async Task WriteProblemDetailsAsync(
+        HttpContext context,
+        int statusCode,
+        string title,
+        string detail
+    )
+    {
+        var problem = new ProblemDetails
+        {
+            // "about:blank" is the RFC 9457 recommendation for standard HTTP errors
+            // with no additional domain-specific semantics. No maintenance required.
+            // Custom URIs will be introduced in Phase 1.5 for domain-specific errors.
+            Type = "about:blank",
+            Title = title,
+            Status = statusCode,
+            Detail = detail,
+            Instance = context.Request.Path,
+        };
+
+        context.Response.StatusCode = statusCode;
+        context.Response.ContentType = "application/problem+json";
+
+        await context.Response.WriteAsync(JsonSerializer.Serialize(problem, JsonOptions));
+    }
+
+    private static string GetTitleForStatusCode(int statusCode) =>
+        statusCode switch
+        {
+            StatusCodes.Status400BadRequest => "Bad Request",
+            StatusCodes.Status404NotFound => "Not Found",
+            StatusCodes.Status409Conflict => "Conflict",
+            _ => "An error occurred",
+        };
+}

--- a/FeatureFlag.Api/Program.cs
+++ b/FeatureFlag.Api/Program.cs
@@ -25,6 +25,9 @@ builder.Services.AddInfrastructure(builder.Configuration);
 
 WebApplication app = builder.Build();
 
+// Must be first — wraps the entire pipeline
+app.UseMiddleware<FeatureFlag.Api.Middleware.GlobalExceptionMiddleware>();
+
 if (app.Environment.IsDevelopment())
 {
     app.MapOpenApi();

--- a/FeatureFlag.Application/Services/FeatureFlagService.cs
+++ b/FeatureFlag.Application/Services/FeatureFlagService.cs
@@ -3,6 +3,7 @@ using FeatureFlag.Application.Evaluation;
 using FeatureFlag.Application.Interfaces;
 using FeatureFlag.Domain.Entities;
 using FeatureFlag.Domain.Enums;
+using FeatureFlag.Domain.Exceptions;
 using FeatureFlag.Domain.Interfaces;
 using FeatureFlag.Domain.ValueObjects;
 
@@ -27,7 +28,7 @@ public sealed class FeatureFlagService : IFeatureFlagService
     {
         Flag flag =
             await _repository.GetByNameAsync(name, environment, ct)
-            ?? throw new KeyNotFoundException($"Flag '{name}' not found in {environment}.");
+            ?? throw new FlagNotFoundException(name);
 
         return flag.ToResponse();
     }
@@ -49,9 +50,7 @@ public sealed class FeatureFlagService : IFeatureFlagService
 
         Flag flag =
             await _repository.GetByNameAsync(flagName, sanitizedContext.Environment, ct)
-            ?? throw new KeyNotFoundException(
-                $"Flag '{flagName}' not found in {sanitizedContext.Environment}."
-            );
+            ?? throw new FlagNotFoundException(flagName);
 
         if (!flag.IsEnabled)
         {
@@ -100,7 +99,7 @@ public sealed class FeatureFlagService : IFeatureFlagService
     {
         Flag flag =
             await _repository.GetByNameAsync(name, environment, ct)
-            ?? throw new KeyNotFoundException($"Flag '{name}' not found in {environment}.");
+            ?? throw new FlagNotFoundException(name);
 
         // Single atomic update — sets UpdatedAt exactly once
         flag.Update(request.IsEnabled, request.StrategyType, request.StrategyConfig);
@@ -115,7 +114,7 @@ public sealed class FeatureFlagService : IFeatureFlagService
     {
         Flag flag =
             await _repository.GetByNameAsync(name, environment, ct)
-            ?? throw new KeyNotFoundException($"Flag '{name}' not found in {environment}.");
+            ?? throw new FlagNotFoundException(name);
 
         flag.Archive();
         await _repository.SaveChangesAsync(ct);

--- a/FeatureFlag.Domain/Exceptions/DuplicateFlagNameException.cs
+++ b/FeatureFlag.Domain/Exceptions/DuplicateFlagNameException.cs
@@ -1,0 +1,17 @@
+using Microsoft.AspNetCore.Http;
+
+namespace FeatureFlag.Domain.Exceptions;
+
+/// <summary>
+/// Thrown when a flag creation attempt conflicts with an existing flag
+/// of the same name in the same environment.
+/// Maps to HTTP 409 Conflict.
+/// </summary>
+public sealed class DuplicateFlagNameException : FeatureFlagException
+{
+    public DuplicateFlagNameException(string flagName)
+        : base(
+            $"A feature flag with name '{flagName}' already exists in this environment.",
+            StatusCodes.Status409Conflict
+        ) { }
+}

--- a/FeatureFlag.Domain/Exceptions/FeatureFlagException.cs
+++ b/FeatureFlag.Domain/Exceptions/FeatureFlagException.cs
@@ -1,0 +1,20 @@
+namespace FeatureFlag.Domain.Exceptions;
+
+/// <summary>
+/// Base class for all domain exceptions in FeatureFlagService.
+/// Carries the HTTP status code that the middleware will use
+/// when building the ProblemDetails response.
+/// </summary>
+public abstract class FeatureFlagException : Exception
+{
+    /// <summary>
+    /// The HTTP status code this exception maps to.
+    /// </summary>
+    public int StatusCode { get; }
+
+    protected FeatureFlagException(string message, int statusCode)
+        : base(message)
+    {
+        StatusCode = statusCode;
+    }
+}

--- a/FeatureFlag.Domain/Exceptions/FlagNotFoundException.cs
+++ b/FeatureFlag.Domain/Exceptions/FlagNotFoundException.cs
@@ -1,0 +1,14 @@
+using Microsoft.AspNetCore.Http;
+
+namespace FeatureFlag.Domain.Exceptions;
+
+/// <summary>
+/// Thrown when a feature flag cannot be found by name and environment.
+/// Maps to HTTP 404 Not Found.
+/// </summary>
+public sealed class FlagNotFoundException : FeatureFlagException
+{
+    public FlagNotFoundException(string flagName)
+        : base($"No feature flag with name '{flagName}' was found.", StatusCodes.Status404NotFound)
+    { }
+}

--- a/FeatureFlag.Domain/FeatureFlag.Domain.csproj
+++ b/FeatureFlag.Domain/FeatureFlag.Domain.csproj
@@ -4,4 +4,9 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
+  <ItemGroup>
+    <!-- Required for StatusCodes constants used in domain exception subclasses. -->
+    <!-- Intentional trade-off: named constants over magic numbers. See spec PR#36. -->
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
- Replaces per-controller try/catch with GlobalExceptionMiddleware as the single error handler. 
- Introduces a named domain exception hierarchy (FeatureFlagException, FlagNotFoundException, DuplicateFlagNameException) so failure modes are explicit and the middleware never needs to change when new exceptions are added (OCP). 
- All error responses now return a consistent RFC 9457 ProblemDetails shape with application/problem+json content type. 
- Updates AI reviewer Rule 8 to enforce the happy-path-only controller contract.