### PR TITLE
fix: IDE1006 violations

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -416,10 +416,15 @@ dotnet_diagnostic.IDE0005.severity = warning
 
 dotnet_diagnostic.IDE0046.severity = none
 
+# IDE1006: Naming Styles
+dotnet_diagnostic.IDE1006.severity = warning
 
 # ============================================================
 # Project files, config, and data files
 # ============================================================
+
+
+
 [*.{csproj,vbproj,vcxproj,props,targets}]
 indent_size = 2
 

--- a/FeatureFlag.Application/Strategies/PercentageStrategy.cs
+++ b/FeatureFlag.Application/Strategies/PercentageStrategy.cs
@@ -10,7 +10,7 @@ namespace FeatureFlag.Application.Strategies;
 
 public sealed class PercentageStrategy : IRolloutStrategy
 {
-    private static readonly JsonSerializerOptions _options = new()
+    private static readonly JsonSerializerOptions Options = new()
     {
         PropertyNameCaseInsensitive = true,
     };
@@ -22,7 +22,7 @@ public sealed class PercentageStrategy : IRolloutStrategy
         PercentageConfig? config;
         try
         {
-            config = JsonSerializer.Deserialize<PercentageConfig>(flag.StrategyConfig, _options);
+            config = JsonSerializer.Deserialize<PercentageConfig>(flag.StrategyConfig, Options);
         }
         catch (JsonException)
         {

--- a/FeatureFlag.Application/Strategies/RoleStrategy.cs
+++ b/FeatureFlag.Application/Strategies/RoleStrategy.cs
@@ -8,7 +8,7 @@ namespace FeatureFlag.Application.Strategies;
 
 public sealed class RoleStrategy : IRolloutStrategy
 {
-    private static readonly JsonSerializerOptions _options = new()
+    private static readonly JsonSerializerOptions Options = new()
     {
         PropertyNameCaseInsensitive = true,
     };
@@ -20,7 +20,7 @@ public sealed class RoleStrategy : IRolloutStrategy
         RoleConfig? config;
         try
         {
-            config = JsonSerializer.Deserialize<RoleConfig>(flag.StrategyConfig, _options);
+            config = JsonSerializer.Deserialize<RoleConfig>(flag.StrategyConfig, Options);
         }
         catch (JsonException)
         {

--- a/FeatureFlag.Tests.Integration/EvaluationEndpointTests.cs
+++ b/FeatureFlag.Tests.Integration/EvaluationEndpointTests.cs
@@ -17,7 +17,7 @@ public sealed class EvaluationEndpointTests : IntegrationTestBase
 
     [Fact]
     [Trait("Category", "Integration")]
-    public async Task Evaluate_EnabledNoneStrategy_ReturnsTrue()
+    public async Task Evaluate_EnabledNoneStrategy_ReturnsTrueAsync()
     {
         // Arrange
         await CreateFlagAsync(name: "enabled-none-flag");
@@ -46,7 +46,7 @@ public sealed class EvaluationEndpointTests : IntegrationTestBase
 
     [Fact]
     [Trait("Category", "Integration")]
-    public async Task Evaluate_DisabledFlag_ReturnsFalse()
+    public async Task Evaluate_DisabledFlag_ReturnsFalseAsync()
     {
         // Arrange
         await CreateFlagAsync(name: "disabled-flag", isEnabled: false);
@@ -75,7 +75,7 @@ public sealed class EvaluationEndpointTests : IntegrationTestBase
 
     [Fact]
     [Trait("Category", "Integration")]
-    public async Task Evaluate_PercentageStrategy_ReturnsDeterministicResult()
+    public async Task Evaluate_PercentageStrategy_ReturnsDeterministicResultAsync()
     {
         // Arrange
         await CreateFlagAsync(
@@ -118,7 +118,7 @@ public sealed class EvaluationEndpointTests : IntegrationTestBase
 
     [Fact]
     [Trait("Category", "Integration")]
-    public async Task Evaluate_RoleStrategy_MatchingRole_ReturnsTrue()
+    public async Task Evaluate_RoleStrategy_MatchingRole_ReturnsTrueAsync()
     {
         // Arrange
         await CreateFlagAsync(
@@ -151,7 +151,7 @@ public sealed class EvaluationEndpointTests : IntegrationTestBase
 
     [Fact]
     [Trait("Category", "Integration")]
-    public async Task Evaluate_RoleStrategy_NoMatchingRole_ReturnsFalse()
+    public async Task Evaluate_RoleStrategy_NoMatchingRole_ReturnsFalseAsync()
     {
         // Arrange
         await CreateFlagAsync(
@@ -184,7 +184,7 @@ public sealed class EvaluationEndpointTests : IntegrationTestBase
 
     [Fact]
     [Trait("Category", "Integration")]
-    public async Task Evaluate_FlagNotFound_Returns404()
+    public async Task Evaluate_FlagNotFound_Returns404Async()
     {
         // Arrange
         var request = new EvaluationRequest(
@@ -209,7 +209,7 @@ public sealed class EvaluationEndpointTests : IntegrationTestBase
 
     [Fact]
     [Trait("Category", "Integration")]
-    public async Task Evaluate_MissingUserId_Returns400()
+    public async Task Evaluate_MissingUserId_Returns400Async()
     {
         // Arrange
         await CreateFlagAsync(name: "missing-user-id-flag");

--- a/FeatureFlag.Tests.Integration/FlagEndpointTests.cs
+++ b/FeatureFlag.Tests.Integration/FlagEndpointTests.cs
@@ -20,7 +20,7 @@ public sealed class FlagEndpointTests : IntegrationTestBase
 
     [Fact]
     [Trait("Category", "Integration")]
-    public async Task CreateFlag_ValidRequest_Returns201WithLocationHeader()
+    public async Task CreateFlag_ValidRequest_Returns201WithLocationHeaderAsync()
     {
         // Arrange
         var payload = new
@@ -62,7 +62,7 @@ public sealed class FlagEndpointTests : IntegrationTestBase
 
     [Fact]
     [Trait("Category", "Integration")]
-    public async Task CreateFlag_NoneStrategyNullConfig_Returns201()
+    public async Task CreateFlag_NoneStrategyNullConfig_Returns201Async()
     {
         // Arrange
         var payload = new
@@ -90,7 +90,7 @@ public sealed class FlagEndpointTests : IntegrationTestBase
 
     [Fact]
     [Trait("Category", "Integration")]
-    public async Task CreateFlag_InvalidName_Returns400WithValidationErrors()
+    public async Task CreateFlag_InvalidName_Returns400WithValidationErrorsAsync()
     {
         // Arrange
         var payload = new
@@ -117,7 +117,7 @@ public sealed class FlagEndpointTests : IntegrationTestBase
 
     [Fact]
     [Trait("Category", "Integration")]
-    public async Task CreateFlag_DuplicateNameAndEnvironment_Returns409()
+    public async Task CreateFlag_DuplicateNameAndEnvironment_Returns409Async()
     {
         // Arrange
         await CreateFlagAsync(name: "duplicate-flag");
@@ -145,7 +145,7 @@ public sealed class FlagEndpointTests : IntegrationTestBase
 
     [Fact]
     [Trait("Category", "Integration")]
-    public async Task CreateFlag_InvalidPercentageConfig_Returns400()
+    public async Task CreateFlag_InvalidPercentageConfig_Returns400Async()
     {
         // Arrange
         var payload = new
@@ -172,7 +172,7 @@ public sealed class FlagEndpointTests : IntegrationTestBase
 
     [Fact]
     [Trait("Category", "Integration")]
-    public async Task GetAllFlags_WithFlags_Returns200WithList()
+    public async Task GetAllFlags_WithFlags_Returns200WithListAsync()
     {
         // Arrange
         await CreateFlagAsync(name: "flag-a");
@@ -193,7 +193,7 @@ public sealed class FlagEndpointTests : IntegrationTestBase
 
     [Fact]
     [Trait("Category", "Integration")]
-    public async Task GetAllFlags_NoFlags_Returns200EmptyArray()
+    public async Task GetAllFlags_NoFlags_Returns200EmptyArrayAsync()
     {
         // Arrange
 
@@ -211,7 +211,7 @@ public sealed class FlagEndpointTests : IntegrationTestBase
 
     [Fact]
     [Trait("Category", "Integration")]
-    public async Task GetAllFlags_FiltersByEnvironment_ReturnsOnlyMatching()
+    public async Task GetAllFlags_FiltersByEnvironment_ReturnsOnlyMatchingAsync()
     {
         // Arrange
         await CreateFlagAsync(name: "dev-flag", environment: EnvironmentType.Development);
@@ -233,7 +233,7 @@ public sealed class FlagEndpointTests : IntegrationTestBase
 
     [Fact]
     [Trait("Category", "Integration")]
-    public async Task GetAllFlags_ExcludesArchivedFlags()
+    public async Task GetAllFlags_ExcludesArchivedFlagsAsync()
     {
         // Arrange
         await CreateFlagAsync(name: "archived-flag");
@@ -256,7 +256,7 @@ public sealed class FlagEndpointTests : IntegrationTestBase
 
     [Fact]
     [Trait("Category", "Integration")]
-    public async Task GetFlagByName_Exists_Returns200WithCorrectBody()
+    public async Task GetFlagByName_Exists_Returns200WithCorrectBodyAsync()
     {
         // Arrange
         FlagResponse created = await CreateFlagAsync(name: "by-name-flag");
@@ -276,7 +276,7 @@ public sealed class FlagEndpointTests : IntegrationTestBase
 
     [Fact]
     [Trait("Category", "Integration")]
-    public async Task GetFlagByName_NotFound_Returns404ProblemDetails()
+    public async Task GetFlagByName_NotFound_Returns404ProblemDetailsAsync()
     {
         // Arrange
 
@@ -293,7 +293,7 @@ public sealed class FlagEndpointTests : IntegrationTestBase
 
     [Fact]
     [Trait("Category", "Integration")]
-    public async Task GetFlagByName_InvalidRouteName_Returns400ProblemDetails()
+    public async Task GetFlagByName_InvalidRouteName_Returns400ProblemDetailsAsync()
     {
         // Arrange
 
@@ -311,7 +311,7 @@ public sealed class FlagEndpointTests : IntegrationTestBase
 
     [Fact]
     [Trait("Category", "Integration")]
-    public async Task UpdateFlag_ValidRequest_Returns204()
+    public async Task UpdateFlag_ValidRequest_Returns204Async()
     {
         // Arrange
         await CreateFlagAsync(name: "update-flag");
@@ -340,7 +340,7 @@ public sealed class FlagEndpointTests : IntegrationTestBase
 
     [Fact]
     [Trait("Category", "Integration")]
-    public async Task UpdateFlag_NotFound_Returns404()
+    public async Task UpdateFlag_NotFound_Returns404Async()
     {
         // Arrange
         var payload = new
@@ -365,7 +365,7 @@ public sealed class FlagEndpointTests : IntegrationTestBase
 
     [Fact]
     [Trait("Category", "Integration")]
-    public async Task UpdateFlag_InvalidStrategyConfig_Returns400()
+    public async Task UpdateFlag_InvalidStrategyConfig_Returns400Async()
     {
         // Arrange
         await CreateFlagAsync(name: "update-invalid-config");
@@ -391,7 +391,7 @@ public sealed class FlagEndpointTests : IntegrationTestBase
 
     [Fact]
     [Trait("Category", "Integration")]
-    public async Task ArchiveFlag_Exists_Returns204AndExcludedFromGetAll()
+    public async Task ArchiveFlag_Exists_Returns204AndExcludedFromGetAllAsync()
     {
         // Arrange
         await CreateFlagAsync(name: "archive-flag");
@@ -416,7 +416,7 @@ public sealed class FlagEndpointTests : IntegrationTestBase
 
     [Fact]
     [Trait("Category", "Integration")]
-    public async Task ArchiveFlag_AllowsNameReuse_ReturnsCreatedOnRecreate()
+    public async Task ArchiveFlag_AllowsNameReuse_ReturnsCreatedOnRecreateAsync()
     {
         // Arrange
         FlagResponse original = await CreateFlagAsync(name: "reusable-flag");
@@ -435,7 +435,7 @@ public sealed class FlagEndpointTests : IntegrationTestBase
 
     [Fact]
     [Trait("Category", "Integration")]
-    public async Task GetAllFlags_InvalidEnvironment_Returns400ProblemDetails()
+    public async Task GetAllFlags_InvalidEnvironment_Returns400ProblemDetailsAsync()
     {
         // Arrange
 
@@ -450,7 +450,7 @@ public sealed class FlagEndpointTests : IntegrationTestBase
 
     [Fact]
     [Trait("Category", "Integration")]
-    public async Task GetFlagByName_InvalidEnvironment_Returns400ProblemDetails()
+    public async Task GetFlagByName_InvalidEnvironment_Returns400ProblemDetailsAsync()
     {
         // Arrange
 
@@ -467,7 +467,7 @@ public sealed class FlagEndpointTests : IntegrationTestBase
 
     [Fact]
     [Trait("Category", "Integration")]
-    public async Task UpdateFlag_InvalidRouteName_Returns400ProblemDetails()
+    public async Task UpdateFlag_InvalidRouteName_Returns400ProblemDetailsAsync()
     {
         // Arrange
         var payload = new
@@ -493,7 +493,7 @@ public sealed class FlagEndpointTests : IntegrationTestBase
 
     [Fact]
     [Trait("Category", "Integration")]
-    public async Task UpdateFlag_InvalidEnvironment_Returns400ProblemDetails()
+    public async Task UpdateFlag_InvalidEnvironment_Returns400ProblemDetailsAsync()
     {
         // Arrange
         var payload = new
@@ -518,7 +518,7 @@ public sealed class FlagEndpointTests : IntegrationTestBase
 
     [Fact]
     [Trait("Category", "Integration")]
-    public async Task ArchiveFlag_NotFound_Returns404ProblemDetails()
+    public async Task ArchiveFlag_NotFound_Returns404ProblemDetailsAsync()
     {
         // Arrange
 
@@ -535,7 +535,7 @@ public sealed class FlagEndpointTests : IntegrationTestBase
 
     [Fact]
     [Trait("Category", "Integration")]
-    public async Task ArchiveFlag_InvalidRouteName_Returns400ProblemDetails()
+    public async Task ArchiveFlag_InvalidRouteName_Returns400ProblemDetailsAsync()
     {
         // Arrange
 
@@ -553,7 +553,7 @@ public sealed class FlagEndpointTests : IntegrationTestBase
 
     [Fact]
     [Trait("Category", "Integration")]
-    public async Task ArchiveFlag_InvalidEnvironment_Returns400ProblemDetails()
+    public async Task ArchiveFlag_InvalidEnvironment_Returns400ProblemDetailsAsync()
     {
         // Arrange
 

--- a/FeatureFlag.Tests/Validators/CreateFlagRequestValidatorTests.cs
+++ b/FeatureFlag.Tests/Validators/CreateFlagRequestValidatorTests.cs
@@ -11,7 +11,7 @@ public sealed class CreateFlagRequestValidatorTests
 {
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task Validate_WhenNameIsEmpty_ReturnsInvalid()
+    public async Task Validate_WhenNameIsEmpty_ReturnsInvalidAsync()
     {
         // Arrange
         var validator = new CreateFlagRequestValidator();
@@ -33,7 +33,7 @@ public sealed class CreateFlagRequestValidatorTests
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task Validate_WhenNameIsWhitespaceOnly_ReturnsInvalid()
+    public async Task Validate_WhenNameIsWhitespaceOnly_ReturnsInvalidAsync()
     {
         // Arrange
         var validator = new CreateFlagRequestValidator();
@@ -55,7 +55,7 @@ public sealed class CreateFlagRequestValidatorTests
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task Validate_WhenNameExceedsMaxLength_ReturnsInvalid()
+    public async Task Validate_WhenNameExceedsMaxLength_ReturnsInvalidAsync()
     {
         // Arrange
         var validator = new CreateFlagRequestValidator();
@@ -81,7 +81,7 @@ public sealed class CreateFlagRequestValidatorTests
     [InlineData("flag.name")]
     [InlineData("flag/name")]
     [Trait("Category", "Unit")]
-    public async Task Validate_WhenNameContainsInvalidCharacters_ReturnsInvalid(string name)
+    public async Task Validate_WhenNameContainsInvalidCharacters_ReturnsInvalidAsync(string name)
     {
         // Arrange
         var validator = new CreateFlagRequestValidator();
@@ -103,7 +103,7 @@ public sealed class CreateFlagRequestValidatorTests
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task Validate_WhenNameHasPaddedWhitespace_ReturnsValid()
+    public async Task Validate_WhenNameHasPaddedWhitespace_ReturnsValidAsync()
     {
         // Arrange
         // The validator runs the regex on the cleaned value; the service layer
@@ -126,7 +126,7 @@ public sealed class CreateFlagRequestValidatorTests
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task Validate_WhenNameUsesAllowedCharacters_ReturnsValid()
+    public async Task Validate_WhenNameUsesAllowedCharacters_ReturnsValidAsync()
     {
         // Arrange
         var validator = new CreateFlagRequestValidator();
@@ -147,7 +147,7 @@ public sealed class CreateFlagRequestValidatorTests
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task Validate_WhenEnvironmentIsNone_ReturnsInvalid()
+    public async Task Validate_WhenEnvironmentIsNone_ReturnsInvalidAsync()
     {
         // Arrange
         var validator = new CreateFlagRequestValidator();
@@ -172,7 +172,7 @@ public sealed class CreateFlagRequestValidatorTests
     [InlineData(EnvironmentType.Staging)]
     [InlineData(EnvironmentType.Production)]
     [Trait("Category", "Unit")]
-    public async Task Validate_WhenEnvironmentIsValid_ReturnsValid(EnvironmentType env)
+    public async Task Validate_WhenEnvironmentIsValid_ReturnsValidAsync(EnvironmentType env)
     {
         // Arrange
         var validator = new CreateFlagRequestValidator();
@@ -187,7 +187,7 @@ public sealed class CreateFlagRequestValidatorTests
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task Validate_WhenStrategyIsNoneButConfigIsProvided_ReturnsInvalid()
+    public async Task Validate_WhenStrategyIsNoneButConfigIsProvided_ReturnsInvalidAsync()
     {
         // Arrange
         var validator = new CreateFlagRequestValidator();
@@ -209,7 +209,7 @@ public sealed class CreateFlagRequestValidatorTests
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task Validate_WhenStrategyIsNoneAndConfigIsNull_ReturnsValid()
+    public async Task Validate_WhenStrategyIsNoneAndConfigIsNull_ReturnsValidAsync()
     {
         // Arrange
         var validator = new CreateFlagRequestValidator();
@@ -230,7 +230,7 @@ public sealed class CreateFlagRequestValidatorTests
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task Validate_WhenStrategyIsPercentageWithValidConfig_ReturnsValid()
+    public async Task Validate_WhenStrategyIsPercentageWithValidConfig_ReturnsValidAsync()
     {
         // Arrange
         var validator = new CreateFlagRequestValidator();
@@ -251,7 +251,7 @@ public sealed class CreateFlagRequestValidatorTests
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task Validate_WhenStrategyIsPercentageWithNullConfig_ReturnsInvalid()
+    public async Task Validate_WhenStrategyIsPercentageWithNullConfig_ReturnsInvalidAsync()
     {
         // Arrange
         var validator = new CreateFlagRequestValidator();
@@ -273,7 +273,7 @@ public sealed class CreateFlagRequestValidatorTests
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task Validate_WhenStrategyIsPercentageWithInvalidConfig_ReturnsInvalid()
+    public async Task Validate_WhenStrategyIsPercentageWithInvalidConfig_ReturnsInvalidAsync()
     {
         // Arrange
         var validator = new CreateFlagRequestValidator();
@@ -295,7 +295,7 @@ public sealed class CreateFlagRequestValidatorTests
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task Validate_WhenStrategyIsRoleBasedWithValidConfig_ReturnsValid()
+    public async Task Validate_WhenStrategyIsRoleBasedWithValidConfig_ReturnsValidAsync()
     {
         // Arrange
         var validator = new CreateFlagRequestValidator();
@@ -316,7 +316,7 @@ public sealed class CreateFlagRequestValidatorTests
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task Validate_WhenStrategyIsRoleBasedWithNullConfig_ReturnsInvalid()
+    public async Task Validate_WhenStrategyIsRoleBasedWithNullConfig_ReturnsInvalidAsync()
     {
         // Arrange
         var validator = new CreateFlagRequestValidator();
@@ -338,7 +338,7 @@ public sealed class CreateFlagRequestValidatorTests
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task Validate_WhenStrategyIsRoleBasedWithInvalidConfig_ReturnsInvalid()
+    public async Task Validate_WhenStrategyIsRoleBasedWithInvalidConfig_ReturnsInvalidAsync()
     {
         // Arrange
         var validator = new CreateFlagRequestValidator();
@@ -360,7 +360,7 @@ public sealed class CreateFlagRequestValidatorTests
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task Validate_WhenStrategyConfigExceedsMaxLength_ReturnsInvalid()
+    public async Task Validate_WhenStrategyConfigExceedsMaxLength_ReturnsInvalidAsync()
     {
         // Arrange
         // Use Percentage strategy so the config field is expected; the 2000-char

--- a/FeatureFlag.Tests/Validators/EvaluationRequestValidatorTests.cs
+++ b/FeatureFlag.Tests/Validators/EvaluationRequestValidatorTests.cs
@@ -11,7 +11,7 @@ public sealed class EvaluationRequestValidatorTests
 {
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task Validate_WhenFlagNameIsEmpty_ReturnsInvalid()
+    public async Task Validate_WhenFlagNameIsEmpty_ReturnsInvalidAsync()
     {
         // Arrange
         var validator = new EvaluationRequestValidator();
@@ -27,7 +27,7 @@ public sealed class EvaluationRequestValidatorTests
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task Validate_WhenFlagNameExceedsMaxLength_ReturnsInvalid()
+    public async Task Validate_WhenFlagNameExceedsMaxLength_ReturnsInvalidAsync()
     {
         // Arrange
         var validator = new EvaluationRequestValidator();
@@ -48,7 +48,7 @@ public sealed class EvaluationRequestValidatorTests
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task Validate_WhenUserIdIsEmpty_ReturnsInvalid()
+    public async Task Validate_WhenUserIdIsEmpty_ReturnsInvalidAsync()
     {
         // Arrange
         var validator = new EvaluationRequestValidator();
@@ -64,7 +64,7 @@ public sealed class EvaluationRequestValidatorTests
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task Validate_WhenUserIdExceedsMaxLength_ReturnsInvalid()
+    public async Task Validate_WhenUserIdExceedsMaxLength_ReturnsInvalidAsync()
     {
         // Arrange
         var validator = new EvaluationRequestValidator();
@@ -85,7 +85,7 @@ public sealed class EvaluationRequestValidatorTests
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task Validate_WhenEnvironmentIsNone_ReturnsInvalid()
+    public async Task Validate_WhenEnvironmentIsNone_ReturnsInvalidAsync()
     {
         // Arrange
         var validator = new EvaluationRequestValidator();
@@ -101,7 +101,7 @@ public sealed class EvaluationRequestValidatorTests
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task Validate_WhenUserRolesIsNull_ReturnsInvalid()
+    public async Task Validate_WhenUserRolesIsNull_ReturnsInvalidAsync()
     {
         // Arrange
         var validator = new EvaluationRequestValidator();
@@ -122,7 +122,7 @@ public sealed class EvaluationRequestValidatorTests
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task Validate_WhenUserRolesIsEmpty_ReturnsValid()
+    public async Task Validate_WhenUserRolesIsEmpty_ReturnsValidAsync()
     {
         // Arrange
         // An empty roles array is a legitimate state — the user is authenticated
@@ -139,7 +139,7 @@ public sealed class EvaluationRequestValidatorTests
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task Validate_WhenUserRolesExceedsMaxCount_ReturnsInvalid()
+    public async Task Validate_WhenUserRolesExceedsMaxCount_ReturnsInvalidAsync()
     {
         // Arrange
         var validator = new EvaluationRequestValidator();
@@ -160,7 +160,7 @@ public sealed class EvaluationRequestValidatorTests
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task Validate_WhenSingleRoleExceedsMaxLength_ReturnsInvalid()
+    public async Task Validate_WhenSingleRoleExceedsMaxLength_ReturnsInvalidAsync()
     {
         // Arrange
         // FluentValidation's RuleForEach generates property names in the format
@@ -183,7 +183,7 @@ public sealed class EvaluationRequestValidatorTests
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task Validate_WhenAllFieldsAreValid_ReturnsValid()
+    public async Task Validate_WhenAllFieldsAreValid_ReturnsValidAsync()
     {
         // Arrange
         var validator = new EvaluationRequestValidator();

--- a/FeatureFlag.Tests/Validators/UpdateFlagRequestValidatorTests.cs
+++ b/FeatureFlag.Tests/Validators/UpdateFlagRequestValidatorTests.cs
@@ -11,7 +11,7 @@ public sealed class UpdateFlagRequestValidatorTests
 {
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task Validate_WhenStrategyIsNoneButConfigIsProvided_ReturnsInvalid()
+    public async Task Validate_WhenStrategyIsNoneButConfigIsProvided_ReturnsInvalidAsync()
     {
         // Arrange
         var validator = new UpdateFlagRequestValidator();
@@ -27,7 +27,7 @@ public sealed class UpdateFlagRequestValidatorTests
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task Validate_WhenStrategyIsNoneAndConfigIsNull_ReturnsValid()
+    public async Task Validate_WhenStrategyIsNoneAndConfigIsNull_ReturnsValidAsync()
     {
         // Arrange
         var validator = new UpdateFlagRequestValidator();
@@ -42,7 +42,7 @@ public sealed class UpdateFlagRequestValidatorTests
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task Validate_WhenStrategyIsPercentageWithValidConfig_ReturnsValid()
+    public async Task Validate_WhenStrategyIsPercentageWithValidConfig_ReturnsValidAsync()
     {
         // Arrange
         var validator = new UpdateFlagRequestValidator();
@@ -61,7 +61,7 @@ public sealed class UpdateFlagRequestValidatorTests
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task Validate_WhenStrategyIsPercentageWithNullConfig_ReturnsInvalid()
+    public async Task Validate_WhenStrategyIsPercentageWithNullConfig_ReturnsInvalidAsync()
     {
         // Arrange
         var validator = new UpdateFlagRequestValidator();
@@ -77,7 +77,7 @@ public sealed class UpdateFlagRequestValidatorTests
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task Validate_WhenStrategyIsPercentageWithInvalidConfig_ReturnsInvalid()
+    public async Task Validate_WhenStrategyIsPercentageWithInvalidConfig_ReturnsInvalidAsync()
     {
         // Arrange
         var validator = new UpdateFlagRequestValidator();
@@ -97,7 +97,7 @@ public sealed class UpdateFlagRequestValidatorTests
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task Validate_WhenStrategyIsRoleBasedWithValidConfig_ReturnsValid()
+    public async Task Validate_WhenStrategyIsRoleBasedWithValidConfig_ReturnsValidAsync()
     {
         // Arrange
         var validator = new UpdateFlagRequestValidator();
@@ -116,7 +116,7 @@ public sealed class UpdateFlagRequestValidatorTests
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task Validate_WhenStrategyIsRoleBasedWithNullConfig_ReturnsInvalid()
+    public async Task Validate_WhenStrategyIsRoleBasedWithNullConfig_ReturnsInvalidAsync()
     {
         // Arrange
         var validator = new UpdateFlagRequestValidator();
@@ -132,7 +132,7 @@ public sealed class UpdateFlagRequestValidatorTests
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task Validate_WhenStrategyIsRoleBasedWithInvalidConfig_ReturnsInvalid()
+    public async Task Validate_WhenStrategyIsRoleBasedWithInvalidConfig_ReturnsInvalidAsync()
     {
         // Arrange
         var validator = new UpdateFlagRequestValidator();
@@ -152,7 +152,7 @@ public sealed class UpdateFlagRequestValidatorTests
 
     [Fact]
     [Trait("Category", "Unit")]
-    public async Task Validate_WhenStrategyConfigExceedsMaxLength_ReturnsInvalid()
+    public async Task Validate_WhenStrategyConfigExceedsMaxLength_ReturnsInvalidAsync()
     {
         // Arrange
         var validator = new UpdateFlagRequestValidator();


### PR DESCRIPTION
- Rename _options static readonly fields to Options in RoleStrategy and PercentageStrategy to satisfy the static readonly PascalCase naming rule

- Add missing Async suffix to all async test methods in UpdateFlagRequestValidatorTests, EvaluationEndpointTests, and FlagEndpointTests