### PR TITLE
feat: add evaluation decision logging

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -11,7 +11,9 @@
       "Bash(git:*)",
       "Bash(dotnet format:*)",
       "Bash(dotnet test:*)",
-      "Bash(dotnet csharpier:*)"
+      "Bash(dotnet csharpier:*)",
+      "Bash(find /workspaces/FeatureFlagService/FeatureFlag.Tests -name \"*.cs\" -type f -exec grep -l \"new FeatureFlagService\\\\|Mock\\\\|Moq\" {} \\\\;)",
+      "Bash(grep -r \"FeatureFlagService\" /workspaces/FeatureFlagService/FeatureFlag.Tests* --include=\"*.cs\")"
     ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -480,3 +480,6 @@ $RECYCLE.BIN/
 
 # Vim temporary swap files
 *.swp
+
+# Claude local settings
+.claude/settings.local.json

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,5 +7,6 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <!-- Suppress CS1591: missing XML doc comments — not required on all members -->
     <NoWarn>$(NoWarn);1591</NoWarn>
+    <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
   </PropertyGroup>
 </Project>

--- a/Docs/Decisions/evaluation-logging - PR#48/implementation-notes.md
+++ b/Docs/Decisions/evaluation-logging - PR#48/implementation-notes.md
@@ -1,0 +1,80 @@
+# feature/evaluation-logging — Implementation Notes
+**Session date:** 2026-04-09
+**Branch:** `feature/evaluation-logging`
+**Spec reference:** `Docs/Decisions/evaluation-logging - PR#48/spec.md`
+**Build status:** Passed — 0 warnings, 0 errors
+**Tests:** 110/110 passing
+**PR:** 48
+
+## Table of Contents
+- [Summary](#summary)
+- [Implemented Scope](#implemented-scope)
+- [Implementation Notes](#implementation-notes)
+- [Spec Deviations](#spec-deviations)
+- [Verification](#verification)
+
+## Summary
+This PR added structured evaluation decision logging to `FeatureFlagService`,
+modeled evaluation outcomes as a discriminated union in
+`FeatureFlag.Application/Evaluation/`, and added focused unit tests covering the
+new logging behavior without changing the evaluator, controller, or existing test
+files.
+
+## Implemented Scope
+- Added `FeatureFlag.Application/Evaluation/EvaluationResult.cs` with:
+  `EvaluationReason`, `EvaluationResult`, `FlagDisabled`, and
+  `StrategyEvaluated`.
+- Updated `FeatureFlag.Application/Services/FeatureFlagService.cs` to:
+  accept `ILogger<FeatureFlagService>`, log a warning before
+  `FlagNotFoundException`, construct `EvaluationResult` instances, and emit
+  structured completion logs.
+- Added `HashUserId(...)` to keep raw `UserId` values out of logs while still
+  allowing deterministic correlation across evaluations.
+- Added `FeatureFlag.Tests/Services/FeatureFlagServiceLoggingTests.cs` with four
+  unit tests covering disabled-flag logging, strategy-evaluated logging, hashed
+  user IDs, and the not-found warning path.
+- Added `Microsoft.Extensions.Diagnostics.Testing` to
+  `FeatureFlag.Tests/FeatureFlag.Tests.csproj` for `FakeLogger<T>`.
+
+## Implementation Notes
+The final design stayed aligned with the spec's intended architecture:
+
+- `FeatureEvaluator` remains pure and unchanged.
+- `FeatureFlagService` remains the imperative shell and owns all logging.
+- The service still preserves the existing sanitization block before evaluation.
+- The log shape differs by outcome branch while sharing the common
+  `"Flag evaluation complete."` prefix for successful evaluation outcomes.
+
+The new tests verify the structured logging contract directly through
+`FakeLogRecord.GetStructuredStateValue(...)` rather than relying only on rendered
+message text. This makes the assertions stricter for fields like `Reason`,
+`StrategyType`, and hashed `UserId`.
+
+## Spec Deviations
+Two small implementation deviations were made during coding:
+
+1. `FeatureFlagService.LogResult(...)` now returns early when
+   `_logger.IsEnabled(LogLevel.Information)` is false. This was added to satisfy
+   analyzer rule `CA1873` and to avoid unnecessary SHA256 hashing work when info
+   logging is disabled. It does not change behavior when info logging is enabled.
+2. The new logging tests assert structured state via
+   `FakeLogRecord.GetStructuredStateValue(...)` for key fields instead of relying
+   only on rendered message substrings. This is slightly stronger than the spec's
+   example assertions and better verifies the structured telemetry contract.
+
+## Verification
+The implementation was verified with:
+
+```bash
+dotnet csharpier format .
+dotnet build FeatureFlagService.sln
+dotnet test FeatureFlagService.sln --filter "Category=Unit"
+dotnet test FeatureFlagService.sln --filter "Category=Integration"
+dotnet csharpier check .
+```
+
+Final result:
+- Build: passed with 0 warnings / 0 errors
+- Unit tests: 79/79 passing
+- Integration tests: 31/31 passing
+- Total: 110/110 passing

--- a/Docs/Decisions/evaluation-logging - PR#48/spec.md
+++ b/Docs/Decisions/evaluation-logging - PR#48/spec.md
@@ -1,0 +1,799 @@
+# Specification: Evaluation Decision Logging — Phase 1
+
+**Document:** `Docs/Decisions/evaluation-logging-PR#48/spec.md`
+**Status:** Ready for Implementation
+**Branch:** `feature/evaluation-logging`
+**Phase:** 1 — Developer Experience
+**Author:** Jose / Claude Architect Session
+**Date:** 2026-04-09
+
+---
+
+## Table of Contents
+
+- [User Story](#user-story)
+- [Goals and Non-Goals](#goals-and-non-goals)
+- [Architecture Context](#architecture-context)
+- [Design Decisions](#design-decisions)
+- [New Files](#new-files)
+  - [EvaluationResult.cs](#evaluationresultcs)
+- [Modified Files](#modified-files)
+  - [FeatureFlagService.cs](#featureflagservicecs)
+- [New Test File](#new-test-file)
+  - [FeatureFlagServiceLoggingTests.cs](#featureflagserviceloggingtestscs)
+- [Folder Structure After Implementation](#folder-structure-after-implementation)
+- [No-Change Files](#no-change-files)
+- [Acceptance Criteria](#acceptance-criteria)
+- [Out of Scope](#out-of-scope)
+- [Build and Format Sequence](#build-and-format-sequence)
+- [Instructions for Claude Code](#instructions-for-claude-code)
+
+---
+
+## User Story
+
+> As a developer running FeatureFlagService locally or in staging, I want every
+> flag evaluation decision to produce a structured log entry so that I can
+> understand why a flag evaluated to `true` or `false` without attaching a
+> debugger or adding temporary code.
+
+---
+
+## Goals and Non-Goals
+
+**Goals:**
+- Produce a structured log entry for every completed evaluation in `IsEnabledAsync`
+- Capture evaluation reason as a first-class machine-readable field — not inferred
+  from message shape or the presence/absence of other fields
+- Model evaluation outcomes as a discriminated union — typed, immutable, exhaustive
+- Keep `FeatureEvaluator` pure — no logging, no side effects
+- Log a hashed surrogate for `UserId` — not the raw value — to avoid PII in
+  centralized telemetry and prevent high-cardinality dimension pressure
+- Zero new NuGet packages for production code — `ILogger<T>` is already in the container
+- Add `Microsoft.Extensions.Diagnostics.Testing` to `FeatureFlag.Tests` for `FakeLogger<T>`
+- Keep the new logging tests self-contained by using a tiny in-file repository fake
+  instead of introducing a separate mocking-library dependency
+- Phase 4-ready — `EvaluationResult` and `EvaluationReason` are the direct foundation
+  for the trace endpoint
+- Protect new logging behavior with targeted unit tests
+
+**Non-Goals:**
+- No database table for evaluation logs — that is Phase 4
+- No changes to `IFeatureFlagService` interface signatures
+- No changes to `EvaluationController`
+- No changes to `FeatureEvaluator`
+- No Application Insights integration — that is Phase 1.5
+- No logging of `FlagNotFoundException` as a union member — error path, not an
+  evaluation outcome; a `LogWarning` before the throw is sufficient
+
+---
+
+## Architecture Context
+
+Read this before writing any code.
+
+```
+POST /api/evaluate
+      │
+      ▼
+EvaluationController          ← unchanged
+      │
+      ▼
+FeatureFlagService             ← MODIFIED
+  IsEnabledAsync()
+      │
+      ├─ Flag not found        → LogWarning → throw FlagNotFoundException
+      │
+      ├─ flag.IsEnabled=false  → build FlagDisabled result → LogResult → return false
+      │
+      └─ _evaluator.Evaluate() → build StrategyEvaluated result → LogResult → return bool
+            │
+            ▼
+      FeatureEvaluator         ← UNCHANGED — pure, no ILogger, no side effects
+```
+
+**Functional principle in play:**
+`FeatureEvaluator` is the pure core. `FeatureFlagService` is the imperative shell.
+Side effects (logging) live in the shell only. The evaluator has no knowledge that
+logging exists.
+
+**Logging infrastructure:**
+`ILogger<T>` is registered automatically by `WebApplication.CreateBuilder()`.
+No `AddLogging()` call is needed in `DependencyInjection.cs`. No new production
+packages required. When Application Insights is added in Phase 1.5, named message
+template parameters automatically become queryable custom dimensions — no code
+changes required.
+
+---
+
+## Design Decisions
+
+### DD-1 — Discriminated Union with Shared `Reason` Field
+
+`EvaluationResult` is modeled as `abstract record` with two `sealed record` subtypes:
+`FlagDisabled` and `StrategyEvaluated`. Each subtype carries only the fields
+relevant to its outcome.
+
+`FlagDisabled` does not carry `StrategyType` or `IsEnabled` — it never reached a
+strategy. The union enforces this at compile time.
+
+`EvaluationReason` is added as a positional parameter on the **base** record so
+every log entry carries a machine-readable reason field regardless of which branch
+fired. Each subtype hardcodes its own reason — there is no way to construct a
+`FlagDisabled` with `EvaluationReason.StrategyEvaluated`.
+
+**Alternative rejected:** A flat `EvaluationResult` with nullable `StrategyType`
+and nullable `IsEnabled` alongside a reason enum. Rejected because nullable
+strategy-specific fields require defensive null checks at every callsite and remove
+the type system's ability to communicate what happened. The union preserves
+compile-time safety for outcome-specific data while still exposing `Reason` on
+the base for shared querying.
+
+---
+
+### DD-2 — Logging in Service, Not in Evaluator
+
+`FeatureEvaluator` is a Singleton with zero dependencies beyond its strategy registry.
+Injecting `ILogger<FeatureEvaluator>` would couple a side-effectful concern to a
+pure dispatch function. It would also create a blind spot: `FeatureEvaluator` never
+sees the `FlagDisabled` path — the service short-circuits before calling it.
+Logging in the evaluator would silently miss half the evaluation outcomes.
+
+---
+
+### DD-3 — Warning Before FlagNotFoundException, Not a Union Member
+
+`FlagNotFoundException` is an error condition, not an evaluation decision. Log a
+`LogWarning` immediately before throwing. This produces a log entry without
+polluting the `EvaluationResult` model with an exceptional case.
+
+---
+
+### DD-4 — Structured Log Templates, Not Interpolated Strings
+
+All `_logger` calls must use message templates with named parameters. Named
+parameters become queryable custom dimensions in App Insights. Interpolated
+strings produce a flat unstructured message that cannot be queried by field.
+
+Both branches share the prefix `"Flag evaluation complete."` for consistent
+App Insights filtering regardless of outcome.
+
+```csharp
+// CORRECT — named parameters become queryable dimensions in App Insights
+_logger.LogInformation(
+    "Flag evaluation complete. Flag={FlagName} Environment={Environment} " +
+    "UserId={UserId} Reason={Reason} Result={Result} Strategy={StrategyType}",
+    s.FlagName, s.Environment, HashUserId(s.UserId),
+    s.Reason, s.IsEnabled ? "enabled" : "disabled", s.StrategyType);
+
+// WRONG — destroys structured data
+_logger.LogInformation($"Flag {s.FlagName} evaluated to {s.IsEnabled}");
+```
+
+---
+
+### DD-5 — Switch Statement for LogResult + UnreachableException Default
+
+`LogResult` is void-returning and side-effectful. A switch statement is the
+correct tool — forcing a switch expression via discards would be obscure.
+
+The `default` branch throws `UnreachableException`. `EvaluationResult` is
+`abstract` but not `sealed` — the compiler cannot guarantee exhaustiveness. If a
+third subtype is added without a corresponding log branch, the exception fires
+immediately rather than silently producing no log entry.
+
+---
+
+### DD-6 — Hashed UserId Surrogate
+
+Raw user IDs are PII. Once logs flow into Application Insights, raw IDs would be
+stored in Azure telemetry and become subject to GDPR/CCPA erasure obligations.
+They also create high-cardinality dimension pressure at scale.
+
+`HashUserId` produces a short deterministic SHA256 fingerprint:
+
+```csharp
+private static string HashUserId(string userId)
+{
+    byte[] bytes = SHA256.HashData(Encoding.UTF8.GetBytes(userId));
+    return Convert.ToHexString(bytes)[..8].ToLowerInvariant();
+}
+```
+
+- **Deterministic** — same user always produces same hash; log entries are
+  correlatable within a session
+- **Pseudonymized** — the raw ID is not logged, but this is not a security boundary;
+  low-entropy IDs may still be guessable via dictionary attack
+- **Fixed width** — the emitted value is always an 8-character lowercase hex string,
+  which keeps the telemetry payload compact even though distinct users still produce
+  distinct values
+
+`HashUserId` is called inside `LogResult` — not when constructing the record.
+The record carries the raw `UserId` so Phase 4 can choose independently what
+to expose to callers. Privacy transformation is a logging concern, not a data
+model concern.
+
+`HashUserId` must be a `private static` method on `FeatureFlagService`. It must
+not be added to `InputSanitizer` — sanitization is about cleaning control characters
+at the HTTP boundary; pseudonymization is a separate concern and must not be mixed in.
+
+---
+
+### DD-7 — Targeted Unit Tests for Logging Behavior
+
+The existing integration tests exercise HTTP outcomes. They do not verify which
+log branch fires, whether `Reason` carries the correct value, or whether the hashed
+UserId appears instead of the raw value. This new behavior is unprotected without
+targeted unit tests.
+
+`FeatureFlagService` is normally integration-tested because `FeatureEvaluator` is
+a concrete sealed class. However, for logging branch tests we construct
+`FeatureEvaluator` directly with a real `NoneStrategy` — no mocking required.
+`IFeatureFlagRepository` is replaced by a tiny in-file fake that implements only
+the behavior these tests need. `ILogger<FeatureFlagService>` is replaced by
+`FakeLogger<FeatureFlagService>` from `Microsoft.Extensions.Diagnostics.Testing`.
+
+---
+
+## New Files
+
+### `EvaluationResult.cs`
+
+**Location:** `FeatureFlag.Application/Evaluation/EvaluationResult.cs`
+
+```csharp
+using FeatureFlag.Domain.Enums;
+
+namespace FeatureFlag.Application.Evaluation;
+
+/// <summary>
+/// Machine-readable reason for a flag evaluation outcome.
+/// Carried on every EvaluationResult subtype for structured log querying
+/// and as the foundation for the Phase 4 trace endpoint.
+/// </summary>
+public enum EvaluationReason
+{
+    FlagDisabled,
+    StrategyEvaluated,
+}
+
+/// <summary>
+/// Discriminated union representing the outcome of a feature flag evaluation.
+/// Each subtype carries only the data relevant to its specific outcome.
+/// Reason is defined on the base so every log entry carries a queryable field
+/// regardless of which branch fired.
+/// </summary>
+public abstract record EvaluationResult(
+    string FlagName,
+    EnvironmentType Environment,
+    string UserId,
+    EvaluationReason Reason
+);
+
+/// <summary>
+/// The flag exists but IsEnabled is false. Strategy was never consulted.
+/// </summary>
+public sealed record FlagDisabled(
+    string FlagName,
+    EnvironmentType Environment,
+    string UserId
+) : EvaluationResult(FlagName, Environment, UserId, EvaluationReason.FlagDisabled);
+
+/// <summary>
+/// The flag is enabled and a rollout strategy produced the final decision.
+/// </summary>
+public sealed record StrategyEvaluated(
+    string FlagName,
+    EnvironmentType Environment,
+    string UserId,
+    bool IsEnabled,
+    RolloutStrategy StrategyType
+) : EvaluationResult(FlagName, Environment, UserId, EvaluationReason.StrategyEvaluated);
+```
+
+> **Why does each subtype hardcode its own `Reason`?**
+> The subtype already *is* the reason — `FlagDisabled` can only ever mean
+> `EvaluationReason.FlagDisabled`. Hardcoding it in the base constructor call means
+> callers cannot accidentally pass the wrong reason. The type system enforces the
+> contract with no runtime check required.
+
+---
+
+## Modified Files
+
+### `FeatureFlagService.cs`
+
+**Location:** `FeatureFlag.Application/Services/FeatureFlagService.cs`
+
+**Changes required:**
+1. Add `using System.Diagnostics;` to the using block
+2. Add `using Microsoft.Extensions.Logging;` to the using block
+3. Add `using System.Security.Cryptography;` to the using block
+4. Add `using System.Text;` to the using block
+5. Add `ILogger<FeatureFlagService>` constructor parameter and `_logger` field
+6. Rewrite `IsEnabledAsync` to build and log an `EvaluationResult`
+7. Add `private void LogResult(EvaluationResult result)` method
+8. Add `private static string HashUserId(string userId)` method
+9. Add `LogWarning` immediately before `throw new FlagNotFoundException`
+
+**Constructor — updated:**
+
+```csharp
+private readonly IFeatureFlagRepository _repository;
+private readonly FeatureEvaluator _evaluator;
+private readonly ILogger<FeatureFlagService> _logger;
+
+public FeatureFlagService(
+    IFeatureFlagRepository repository,
+    FeatureEvaluator evaluator,
+    ILogger<FeatureFlagService> logger)
+{
+    _repository = repository;
+    _evaluator = evaluator;
+    _logger = logger;
+}
+```
+
+**`IsEnabledAsync` — full replacement:**
+
+```csharp
+public async Task<bool> IsEnabledAsync(
+    string flagName,
+    FeatureEvaluationContext context,
+    CancellationToken ct = default)
+{
+    // Sanitize evaluation inputs before SHA256 hashing and HashSet lookups.
+    var sanitizedContext = new FeatureEvaluationContext(
+        userId: Validators.InputSanitizer.Clean(context.UserId) ?? context.UserId,
+        userRoles: Validators.InputSanitizer.CleanCollection(context.UserRoles),
+        environment: context.Environment
+    );
+
+    Flag? flag = await _repository.GetByNameAsync(flagName, sanitizedContext.Environment, ct);
+
+    if (flag is null)
+    {
+        _logger.LogWarning(
+            "Flag evaluation: not found. Flag={FlagName} Environment={Environment}",
+            flagName,
+            sanitizedContext.Environment);
+
+        throw new FlagNotFoundException(flagName);
+    }
+
+    if (!flag.IsEnabled)
+    {
+        var result = new FlagDisabled(
+            FlagName: flagName,
+            Environment: sanitizedContext.Environment,
+            UserId: sanitizedContext.UserId);
+
+        LogResult(result);
+        return false;
+    }
+
+    bool isEnabled = _evaluator.Evaluate(flag, sanitizedContext);
+
+    var strategyResult = new StrategyEvaluated(
+        FlagName: flagName,
+        Environment: sanitizedContext.Environment,
+        UserId: sanitizedContext.UserId,
+        IsEnabled: isEnabled,
+        StrategyType: flag.StrategyType);
+
+    LogResult(strategyResult);
+    return isEnabled;
+}
+```
+
+**`LogResult` — new private method:**
+
+```csharp
+/// <summary>
+/// Writes a structured log entry for a completed evaluation outcome.
+/// UserId is hashed to a short SHA256 surrogate — never logged raw.
+/// Each branch logs only the fields meaningful to that outcome.
+/// </summary>
+private void LogResult(EvaluationResult result)
+{
+    switch (result)
+    {
+        case FlagDisabled d:
+            _logger.LogInformation(
+                "Flag evaluation complete. Flag={FlagName} Environment={Environment} " +
+                "UserId={UserId} Reason={Reason}",
+                d.FlagName,
+                d.Environment,
+                HashUserId(d.UserId),
+                d.Reason);
+            break;
+
+        case StrategyEvaluated s:
+            _logger.LogInformation(
+                "Flag evaluation complete. Flag={FlagName} Environment={Environment} " +
+                "UserId={UserId} Reason={Reason} Result={Result} Strategy={StrategyType}",
+                s.FlagName,
+                s.Environment,
+                HashUserId(s.UserId),
+                s.Reason,
+                s.IsEnabled ? "enabled" : "disabled",
+                s.StrategyType);
+            break;
+
+        default:
+            throw new UnreachableException(
+                $"Unhandled EvaluationResult subtype: {result.GetType().Name}. " +
+                "Add a logging branch for every new EvaluationResult subtype.");
+    }
+}
+```
+
+**`HashUserId` — new private static method:**
+
+```csharp
+/// <summary>
+/// Returns a short deterministic SHA256 fingerprint of the raw UserId.
+/// Deterministic: same input always produces same output — log entries are
+/// correlatable across a session. Not reversible: raw ID cannot be recovered
+/// from the hash.
+/// </summary>
+private static string HashUserId(string userId)
+{
+    byte[] bytes = SHA256.HashData(Encoding.UTF8.GetBytes(userId));
+    return Convert.ToHexString(bytes)[..8].ToLowerInvariant();
+}
+```
+
+---
+
+## New Test File
+
+### `FeatureFlagServiceLoggingTests.cs`
+
+**Location:** `FeatureFlag.Tests/Services/FeatureFlagServiceLoggingTests.cs`
+
+**New package — add to `FeatureFlag.Tests.csproj`:**
+```xml
+<PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="9.*" />
+```
+
+> `FakeLogger<T>` captures log records in memory and exposes them via
+> `FakeLogger.LatestRecord` and `FakeLogger.Collector.GetSnapshot()`. No mocking
+> library is required for the repository — use a tiny in-file fake instead.
+
+```csharp
+using FeatureFlag.Application.Evaluation;
+using FeatureFlag.Application.Services;
+using FeatureFlag.Application.Strategies;
+using FeatureFlag.Domain.Entities;
+using FeatureFlag.Domain.Enums;
+using FeatureFlag.Domain.Exceptions;
+using FeatureFlag.Domain.Interfaces;
+using FeatureFlag.Domain.ValueObjects;
+using Microsoft.Extensions.Diagnostics.Testing;
+using Microsoft.Extensions.Logging;
+
+namespace FeatureFlag.Tests.Services;
+
+[Trait("Category", "Unit")]
+public sealed class FeatureFlagServiceLoggingTests
+{
+    private readonly TestFeatureFlagRepository _repo;
+    private readonly FeatureEvaluator _evaluator;
+    private readonly FakeLogger<FeatureFlagService> _fakeLogger;
+    private readonly FeatureFlagService _service;
+
+    public FeatureFlagServiceLoggingTests()
+    {
+        _repo = new TestFeatureFlagRepository();
+
+        // FeatureEvaluator is a concrete sealed class — construct directly.
+        _evaluator = new FeatureEvaluator(new IRolloutStrategy[] { new NoneStrategy() });
+
+        _fakeLogger = new FakeLogger<FeatureFlagService>();
+        _service = new FeatureFlagService(_repo, _evaluator, _fakeLogger);
+    }
+
+    [Fact]
+    public async Task IsEnabledAsync_DisabledFlag_LogsFlagDisabledReason()
+    {
+        // Arrange
+        _repo.FlagToReturn = new Flag(
+            "my-flag",
+            EnvironmentType.Development,
+            isEnabled: false,
+            RolloutStrategy.None,
+            null);
+
+        var context = new FeatureEvaluationContext("user-1", [], EnvironmentType.Development);
+
+        // Act
+        await _service.IsEnabledAsync("my-flag", context);
+
+        // Assert
+        var record = _fakeLogger.LatestRecord;
+        Assert.Equal(LogLevel.Information, record.Level);
+        Assert.Contains("Reason=FlagDisabled", record.Message);
+        Assert.DoesNotContain("Strategy", record.Message);
+    }
+
+    [Fact]
+    public async Task IsEnabledAsync_EnabledFlag_LogsStrategyEvaluatedReason()
+    {
+        // Arrange
+        _repo.FlagToReturn = new Flag(
+            "my-flag",
+            EnvironmentType.Development,
+            isEnabled: true,
+            RolloutStrategy.None,
+            null);
+
+        var context = new FeatureEvaluationContext("user-1", [], EnvironmentType.Development);
+
+        // Act
+        await _service.IsEnabledAsync("my-flag", context);
+
+        // Assert
+        var record = _fakeLogger.LatestRecord;
+        Assert.Equal(LogLevel.Information, record.Level);
+        Assert.Contains("Reason=StrategyEvaluated", record.Message);
+        Assert.Contains("Strategy=None", record.Message);
+    }
+
+    [Fact]
+    public async Task IsEnabledAsync_AnyOutcome_LogsHashedUserIdNotRaw()
+    {
+        // Arrange
+        _repo.FlagToReturn = new Flag(
+            "my-flag",
+            EnvironmentType.Development,
+            isEnabled: false,
+            RolloutStrategy.None,
+            null);
+
+        const string rawUserId = "user-abc-123";
+        var context = new FeatureEvaluationContext(rawUserId, [], EnvironmentType.Development);
+
+        // Act
+        await _service.IsEnabledAsync("my-flag", context);
+
+        // Assert — raw UserId must not appear anywhere in the log message
+        var record = _fakeLogger.LatestRecord;
+        Assert.DoesNotContain(rawUserId, record.Message);
+    }
+
+    [Fact]
+    public async Task IsEnabledAsync_FlagNotFound_LogsWarningBeforeException()
+    {
+        // Arrange
+        _repo.FlagToReturn = null;
+
+        var context = new FeatureEvaluationContext("user-1", [], EnvironmentType.Development);
+
+        // Act + Assert — exception is expected
+        await Assert.ThrowsAsync<FlagNotFoundException>(
+            () => _service.IsEnabledAsync("missing-flag", context));
+
+        // Warning log must have fired before the throw
+        var record = _fakeLogger.LatestRecord;
+        Assert.Equal(LogLevel.Warning, record.Level);
+        Assert.Contains("missing-flag", record.Message);
+    }
+
+    private sealed class TestFeatureFlagRepository : IFeatureFlagRepository
+    {
+        public Flag? FlagToReturn { get; set; }
+
+        public Task<Flag?> GetByNameAsync(
+            string name,
+            EnvironmentType environment,
+            CancellationToken ct = default) => Task.FromResult(FlagToReturn);
+
+        public Task<bool> ExistsAsync(
+            string name,
+            EnvironmentType environment,
+            CancellationToken ct = default) => throw new NotSupportedException();
+
+        public Task<IReadOnlyList<Flag>> GetAllAsync(
+            EnvironmentType environment,
+            CancellationToken ct = default) => throw new NotSupportedException();
+
+        public Task AddAsync(Flag flag, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task SaveChangesAsync(CancellationToken ct = default) =>
+            throw new NotSupportedException();
+    }
+}
+```
+
+---
+
+## Folder Structure After Implementation
+
+```
+FeatureFlag.Application/
+  Evaluation/
+    EvaluationResult.cs         ← NEW (EvaluationReason enum + abstract record
+                                       + FlagDisabled + StrategyEvaluated)
+    FeatureEvaluator.cs         ← unchanged
+
+  Services/
+    FeatureFlagService.cs       ← MODIFIED (constructor, IsEnabledAsync,
+                                            LogResult, HashUserId)
+
+FeatureFlag.Tests/
+  Services/
+    FeatureFlagServiceLoggingTests.cs   ← NEW (4 unit tests)
+```
+
+---
+
+## No-Change Files
+
+| File | Reason |
+|------|--------|
+| `FeatureEvaluator.cs` | Pure function — no side effects, no ILogger |
+| `IFeatureFlagService.cs` | Interface signatures unchanged |
+| `EvaluationController.cs` | Thin controller — no logging concerns |
+| `DependencyInjection.cs` (Application) | ILogger auto-registered by the host |
+| `DependencyInjection.cs` (Infrastructure) | No changes required |
+| All existing files in `FeatureFlag.Tests` | Existing tests must not be modified |
+| All files in `FeatureFlag.Tests.Integration` | Integration tests not in scope |
+
+---
+
+## Acceptance Criteria
+
+### AC-1 — `EvaluationResult.cs` exists and compiles
+
+- [ ] `EvaluationReason` enum is defined in the same file with two members:
+      `FlagDisabled` and `StrategyEvaluated`
+- [ ] `EvaluationResult` is an `abstract record` with four positional parameters:
+      `FlagName` (`string`), `Environment` (`EnvironmentType`), `UserId` (`string`),
+      `Reason` (`EvaluationReason`)
+- [ ] `FlagDisabled` is a `sealed record` inheriting `EvaluationResult`; carries no
+      additional properties; hardcodes `EvaluationReason.FlagDisabled` in the base
+      constructor call
+- [ ] `StrategyEvaluated` is a `sealed record` inheriting `EvaluationResult`; carries
+      `IsEnabled` (`bool`) and `StrategyType` (`RolloutStrategy`); hardcodes
+      `EvaluationReason.StrategyEvaluated` in the base constructor call
+- [ ] File is in namespace `FeatureFlag.Application.Evaluation`
+- [ ] File is at `FeatureFlag.Application/Evaluation/EvaluationResult.cs`
+
+### AC-2 — `FeatureFlagService` constructor is updated
+
+- [ ] `using System.Diagnostics;` added to the using block
+- [ ] `using Microsoft.Extensions.Logging;` added to the using block
+- [ ] `using System.Security.Cryptography;` added to the using block
+- [ ] `using System.Text;` added to the using block
+- [ ] Constructor has three parameters: `IFeatureFlagRepository`, `FeatureEvaluator`,
+      `ILogger<FeatureFlagService>`
+- [ ] `_logger` stored as a `private readonly` field
+
+### AC-3 — `IsEnabledAsync` builds and logs an `EvaluationResult`
+
+- [ ] Sanitization block is unchanged from the current implementation
+- [ ] Repository return value declared as `Flag?` — not `Flag` (prevents CS8600)
+- [ ] When flag is not found: `LogWarning` fires with `FlagName` and `Environment`
+      as named template parameters; `FlagNotFoundException` thrown immediately after
+- [ ] When `flag.IsEnabled` is false: `FlagDisabled` record constructed with named
+      positional syntax and passed to `LogResult`; method returns `false`
+- [ ] When `_evaluator.Evaluate` runs: `StrategyEvaluated` record constructed with
+      `IsEnabled = isEnabled` and `StrategyType = flag.StrategyType`; passed to
+      `LogResult`; method returns `isEnabled`
+- [ ] No log call uses string interpolation
+
+### AC-4 — `LogResult` is correct
+
+- [ ] Signature: `private void LogResult(EvaluationResult result)`
+- [ ] Uses a `switch` statement dispatching on `EvaluationResult` subtypes
+- [ ] `FlagDisabled` branch: `LogInformation` with named fields `FlagName`,
+      `Environment`, `UserId` (hashed), `Reason`
+- [ ] `StrategyEvaluated` branch: `LogInformation` with named fields `FlagName`,
+      `Environment`, `UserId` (hashed), `Reason`, `Result`, `StrategyType`
+- [ ] Both branches use the shared prefix `"Flag evaluation complete."`
+- [ ] `default` branch throws `UnreachableException` naming the unhandled subtype
+- [ ] `UserId` is never passed to `_logger` directly — always via `HashUserId`
+
+### AC-5 — `HashUserId` is correct
+
+- [ ] Signature: `private static string HashUserId(string userId)`
+- [ ] Uses `SHA256.HashData(Encoding.UTF8.GetBytes(userId))`
+- [ ] Returns `Convert.ToHexString(bytes)[..8].ToLowerInvariant()`
+- [ ] Method is on `FeatureFlagService` — not on `InputSanitizer`
+
+### AC-6 — `FeatureEvaluator` is unchanged
+
+- [ ] `FeatureEvaluator.cs` is byte-for-byte identical to its current committed state
+- [ ] No `ILogger` injected into `FeatureEvaluator`
+- [ ] DI lifetime remains Singleton
+
+### AC-7 — Build and existing tests pass
+
+- [ ] `dotnet build FeatureFlagService.sln` → 0 errors, 0 warnings
+- [ ] `dotnet test --filter "Category=Unit"` → 75 existing + 4 new = 79/79 passing
+- [ ] `dotnet test --filter "Category=Integration"` → 31/31 passing (unchanged)
+- [ ] `dotnet csharpier check .` → 0 violations
+
+### AC-8 — New unit tests pass and cover logging behavior
+
+- [ ] `FeatureFlagServiceLoggingTests` at `FeatureFlag.Tests/Services/FeatureFlagServiceLoggingTests.cs`
+- [ ] `Microsoft.Extensions.Diagnostics.Testing` added to `FeatureFlag.Tests.csproj`
+- [ ] All four tests carry `[Trait("Category", "Unit")]`
+- [ ] Tests use a tiny in-file `IFeatureFlagRepository` fake; no additional mocking
+      library is introduced
+- [ ] `DisabledFlag` test: asserts rendered log contains `Reason=FlagDisabled` and no
+      `Strategy` field
+- [ ] `EnabledFlag` test: asserts rendered log contains `Reason=StrategyEvaluated` and
+      `Strategy=None`
+- [ ] `HashedUserId` test: asserts raw UserId string does not appear in log message
+- [ ] `FlagNotFound` test: asserts `LogLevel.Warning` fires before the exception
+
+### AC-9 — Log output is observable locally
+
+- [ ] `POST /api/evaluate` with valid enabled flag → console shows:
+      `Flag evaluation complete. Flag=... Environment=... UserId=<8-char-hex> Reason=StrategyEvaluated Result=enabled Strategy=...`
+- [ ] With a disabled flag → console shows:
+      `Flag evaluation complete. Flag=... Environment=... UserId=<8-char-hex> Reason=FlagDisabled`
+      (no `Result` or `Strategy` fields)
+- [ ] With a nonexistent flag → console shows a `warn` entry:
+      `Flag evaluation: not found. Flag=... Environment=...`
+
+---
+
+## Out of Scope
+
+- No `EvaluationLog` database table — Phase 4
+- No Application Insights SDK — Phase 1.5
+- No `GET /api/flags/{name}/trace` endpoint — Phase 4
+- No changes to `appsettings.json` log level configuration
+- No Serilog or any third-party logging library
+- No modifications to existing unit or integration test files
+
+---
+
+## Build and Format Sequence
+
+Always run in this exact order:
+
+```bash
+dotnet build FeatureFlagService.sln
+dotnet test --filter "Category=Unit"
+dotnet test --filter "Category=Integration"
+dotnet csharpier format .
+dotnet csharpier check .
+```
+
+CSharpier is the final formatting authority.
+
+---
+
+## Instructions for Claude Code
+
+Read this entire document before writing any code.
+
+**Do not:**
+- Add `ILogger` to `FeatureEvaluator`
+- Modify `IFeatureFlagService`
+- Modify `EvaluationController`
+- Modify any existing test file
+- Use string interpolation in any `_logger` call
+- Use `?` (nullable) on any property of `EvaluationResult` or its subtypes
+- Pass raw `UserId` to any `_logger` call — always via `HashUserId`
+- Add `HashUserId` or any privacy concern to `InputSanitizer`
+
+**Do:**
+- Create `EvaluationResult.cs` exactly as specified in [New Files](#new-files)
+- Modify `FeatureFlagService.cs` exactly as specified in [Modified Files](#modified-files)
+- Create `FeatureFlagServiceLoggingTests.cs` exactly as specified in [New Test File](#new-test-file)
+- Add `Microsoft.Extensions.Diagnostics.Testing` to `FeatureFlag.Tests.csproj`
+- Use the in-file repository fake shown in the test spec; do not add a separate
+  mocking-library dependency just for these tests
+- Preserve the entire sanitization block in `IsEnabledAsync` — do not simplify or remove it
+- Use named positional record syntax when constructing `FlagDisabled` and `StrategyEvaluated`
+- Verify AC-9 manually in the devcontainer before marking complete
+
+---
+
+*FeatureFlagService | feature/evaluation-logging | Phase 1 — Developer Experience | v2*

--- a/FeatureFlag.Api/packages.lock.json
+++ b/FeatureFlag.Api/packages.lock.json
@@ -1,0 +1,255 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net10.0": {
+      "Microsoft.AspNetCore.OpenApi": {
+        "type": "Direct",
+        "requested": "[10.0.5, )",
+        "resolved": "10.0.5",
+        "contentHash": "vTcxIfOPyfFbYk1g8YcXJfkMnlEWVkSnnjxcZLy60zgwiHMRf2SnZR+9E4HlpwKxgE3yfKMOti8J6WfKuKsw6w==",
+        "dependencies": {
+          "Microsoft.OpenApi": "2.0.0"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Design": {
+        "type": "Direct",
+        "requested": "[10.0.4, )",
+        "resolved": "10.0.4",
+        "contentHash": "FmiUU5xdu1chVxnmsu/mEpCKVQ5+lvIxdP0194lE7HfoU1jO4z/9qnWZpd0kSkVve4gOnRm1lE20kkhlMqJJIg==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.Build.Framework": "18.0.2",
+          "Microsoft.CodeAnalysis.CSharp": "5.0.0",
+          "Microsoft.CodeAnalysis.CSharp.Workspaces": "5.0.0",
+          "Microsoft.CodeAnalysis.Workspaces.MSBuild": "5.0.0",
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.4",
+          "Microsoft.Extensions.DependencyModel": "10.0.4",
+          "Mono.TextTemplating": "3.0.0",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "Scalar.AspNetCore": {
+        "type": "Direct",
+        "requested": "[2.*, )",
+        "resolved": "2.13.20",
+        "contentHash": "KLWQcH0YisMa0nzv36S5TcKgZ5seAaTHXVcdG8S3H0UFFtAeBYwSOnzme6S9Ch1Tl9trpa0G8aiCjzF9H9khTw=="
+      },
+      "FluentValidation": {
+        "type": "Transitive",
+        "resolved": "12.1.1",
+        "contentHash": "EPpkIe1yh1a0OXyC100oOA8WMbZvqUu5plwhvYcb7oSELfyUZzfxV48BLhvs3kKo4NwG7MGLNgy1RJiYtT8Dpw=="
+      },
+      "Humanizer.Core": {
+        "type": "Transitive",
+        "resolved": "2.14.1",
+        "contentHash": "lQKvtaTDOXnoVJ20ibTuSIOf2i0uO0MPbDhd1jm238I+U/2ZnRENj0cktKZhtchBMtCUSRQ5v4xBCUbKNmyVMw=="
+      },
+      "Microsoft.Build.Framework": {
+        "type": "Transitive",
+        "resolved": "18.0.2",
+        "contentHash": "sOSb+0J4G/jCBW/YqmRuL0eOMXgfw1KQLdC9TkbvfA5xs7uNm+PBQXJCOzSJGXtZcZrtXozcwxPmUiRUbmd7FA=="
+      },
+      "Microsoft.CodeAnalysis.Analyzers": {
+        "type": "Transitive",
+        "resolved": "3.11.0",
+        "contentHash": "v/EW3UE8/lbEYHoC2Qq7AR/DnmvpgdtAMndfQNmpuIMx/Mto8L5JnuCfdBYtgvalQOtfNCnxFejxuRrryvUTsg=="
+      },
+      "Microsoft.CodeAnalysis.Common": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "ZXRAdvH6GiDeHRyd3q/km8Z44RoM6FBWHd+gen/la81mVnAdHTEsEkO5J0TCNXBymAcx5UYKt5TvgKBhaLJEow==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.CSharp": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "5DSyJ9bk+ATuDy7fp2Zt0mJStDVKbBoiz1DyfAwSa+k4H4IwykAUcV3URelw5b8/iVbfSaOwkwmPUZH6opZKCw==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]"
+        }
+      },
+      "Microsoft.CodeAnalysis.CSharp.Workspaces": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "Al/Q8B+yO8odSqGVpSvrShMFDvlQdIBU//F3E6Rb0YdiLSALE9wh/pvozPNnfmh5HDnvU+mkmSjpz4hQO++jaA==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.CSharp": "[5.0.0]",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]",
+          "Microsoft.CodeAnalysis.Workspaces.Common": "[5.0.0]",
+          "System.Composition": "9.0.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.Workspaces.Common": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "ZbUmIvT6lqTNKiv06Jl5wf0MTMi1vQ1oH7ou4CLcs2C/no/L7EhP3T8y3XXvn9VbqMcJaJnEsNA1jwYUMgc5jg==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]",
+          "System.Composition": "9.0.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.Workspaces.MSBuild": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "/G+LVoAGMz6Ae8nm+PGLxSw+F5RjYx/J7irbTO5uKAPw1bxHyQJLc/YOnpDxt+EpPtYxvC9wvBsg/kETZp1F9Q==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.Build.Framework": "17.11.31",
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Workspaces.Common": "[5.0.0]",
+          "Microsoft.VisualStudio.SolutionPersistence": "1.0.52",
+          "Newtonsoft.Json": "13.0.3",
+          "System.Composition": "9.0.0"
+        }
+      },
+      "Microsoft.EntityFrameworkCore": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "kzTsfFK2GCytp6DDTfQOmxPU4gbGdrIlP7PxrxF3ESNLtfXrC8BoUVZENBN2WORlZPAD7CVX6AYIglgkpXQooA==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.4",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.4"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "qDcJqCfN1XYyX0ID/Hd9/kQTRvlia8S+Yuwyl9uFhBIKnOCbl9WMdGQCzbZUKbkpkfvf3P9CDdXsnxHyE3O0Aw=="
+      },
+      "Microsoft.EntityFrameworkCore.Analyzers": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "pQeMHCyD3yTtCEGnHV4VsgKUvrESo3MR5mnh8sgQ1hWYmI1YFsUutDowBIxkobeWRtaRmBqQAtF7XQFW6FWuNA=="
+      },
+      "Microsoft.EntityFrameworkCore.Relational": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "DOTjTHy93W3TwpMLM4SCm0n57Sc0Jj3+m2S6LSTstKyBB34eT1UouaMS19mpWwvtj42+sRiEjA3+rOTNoNzXFQ==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "10.0.4"
+        }
+      },
+      "Microsoft.Extensions.DependencyModel": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "LiJXylfk8pk+2zsUsITkou3QTFMJ8RNJ0oKKY0Oyjt6HJctGJwPw//ZgoNO4J29zKaT+dR4/PI2jW/znRcspLg=="
+      },
+      "Microsoft.OpenApi": {
+        "type": "Transitive",
+        "resolved": "2.0.0",
+        "contentHash": "GGYLfzV/G/ct80OZ45JxnWP7NvMX1BCugn/lX7TH5o0lcVaviavsLMTxmFV2AybXWjbi3h6FF1vgZiTK6PXndw=="
+      },
+      "Microsoft.VisualStudio.SolutionPersistence": {
+        "type": "Transitive",
+        "resolved": "1.0.52",
+        "contentHash": "oNv2JtYXhpdJrX63nibx1JT3uCESOBQ1LAk7Dtz/sr0+laW0KRM6eKp4CZ3MHDR2siIkKsY8MmUkeP5DKkQQ5w=="
+      },
+      "Mono.TextTemplating": {
+        "type": "Transitive",
+        "resolved": "3.0.0",
+        "contentHash": "YqueG52R/Xej4VVbKuRIodjiAhV0HR/XVbLbNrJhCZnzjnSjgMJ/dCdV0akQQxavX6hp/LC6rqLGLcXeQYU7XA==",
+        "dependencies": {
+          "System.CodeDom": "6.0.0"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "Npgsql": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "q5RfBI+wywJSFUNDE1L4ZbHEHCFTblo8Uf6A6oe4feOUFYiUQXyAf9GBh5qEZpvJaHiEbpBPkQumjEhXCJxdrg=="
+      },
+      "Npgsql.EntityFrameworkCore.PostgreSQL": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "P6EwH0Q4xkaA264iNZDqCPhWt8pscfUGxXazDQg4noBfqjoOlk4hKWfvBjF9ZX3R/9JybRmmJfmxr2iBMj0EpA==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "[10.0.4, 11.0.0)",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.0.4, 11.0.0)",
+          "Npgsql": "10.0.2"
+        }
+      },
+      "System.CodeDom": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "CPc6tWO1LAer3IzfZufDBRL+UZQcj5uS207NHALQzP84Vp/z6wF0Aa0YZImOQY8iStY0A2zI/e3ihKNPfUm8XA=="
+      },
+      "System.Composition": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "3Djj70fFTraOarSKmRnmRy/zm4YurICm+kiCtI0dYRqGJnLX6nJ+G3WYuFJ173cAPax/gh96REcbNiVqcrypFQ==",
+        "dependencies": {
+          "System.Composition.AttributedModel": "9.0.0",
+          "System.Composition.Convention": "9.0.0",
+          "System.Composition.Hosting": "9.0.0",
+          "System.Composition.Runtime": "9.0.0",
+          "System.Composition.TypedParts": "9.0.0"
+        }
+      },
+      "System.Composition.AttributedModel": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "iri00l/zIX9g4lHMY+Nz0qV1n40+jFYAmgsaiNn16xvt2RDwlqByNG4wgblagnDYxm3YSQQ0jLlC/7Xlk9CzyA=="
+      },
+      "System.Composition.Convention": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "+vuqVP6xpi582XIjJi6OCsIxuoTZfR0M7WWufk3uGDeCl3wGW6KnpylUJ3iiXdPByPE0vR5TjJgR6hDLez4FQg==",
+        "dependencies": {
+          "System.Composition.AttributedModel": "9.0.0"
+        }
+      },
+      "System.Composition.Hosting": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "OFqSeFeJYr7kHxDfaViGM1ymk7d4JxK//VSoNF9Ux0gpqkLsauDZpu89kTHHNdCWfSljbFcvAafGyBoY094btQ==",
+        "dependencies": {
+          "System.Composition.Runtime": "9.0.0"
+        }
+      },
+      "System.Composition.Runtime": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "w1HOlQY1zsOWYussjFGZCEYF2UZXgvoYnS94NIu2CBnAGMbXFAX8PY8c92KwUItPmowal68jnVLBCzdrWLeEKA=="
+      },
+      "System.Composition.TypedParts": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "aRZlojCCGEHDKqh43jaDgaVpYETsgd7Nx4g1zwLKMtv4iTo0627715ajEFNpEEBTgLmvZuv8K0EVxc3sM4NWJA==",
+        "dependencies": {
+          "System.Composition.AttributedModel": "9.0.0",
+          "System.Composition.Hosting": "9.0.0",
+          "System.Composition.Runtime": "9.0.0"
+        }
+      },
+      "featureflag.application": {
+        "type": "Project",
+        "dependencies": {
+          "FeatureFlag.Domain": "[1.0.0, )",
+          "FluentValidation": "[12.*, )"
+        }
+      },
+      "featureflag.domain": {
+        "type": "Project"
+      },
+      "featureflag.infrastructure": {
+        "type": "Project",
+        "dependencies": {
+          "FeatureFlag.Application": "[1.0.0, )",
+          "FeatureFlag.Domain": "[1.0.0, )",
+          "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.1, )"
+        }
+      }
+    }
+  }
+}

--- a/FeatureFlag.Application/Evaluation/EvaluationResult.cs
+++ b/FeatureFlag.Application/Evaluation/EvaluationResult.cs
@@ -1,0 +1,44 @@
+using FeatureFlag.Domain.Enums;
+
+namespace FeatureFlag.Application.Evaluation;
+
+/// <summary>
+/// Machine-readable reason for a flag evaluation outcome.
+/// Carried on every EvaluationResult subtype for structured log querying
+/// and as the foundation for the Phase 4 trace endpoint.
+/// </summary>
+public enum EvaluationReason
+{
+    FlagDisabled,
+    StrategyEvaluated,
+}
+
+/// <summary>
+/// Discriminated union representing the outcome of a feature flag evaluation.
+/// Each subtype carries only the data relevant to its specific outcome.
+/// Reason is defined on the base so every log entry carries a queryable field
+/// regardless of which branch fired.
+/// </summary>
+public abstract record EvaluationResult(
+    string FlagName,
+    EnvironmentType Environment,
+    string UserId,
+    EvaluationReason Reason
+);
+
+/// <summary>
+/// The flag exists but IsEnabled is false. Strategy was never consulted.
+/// </summary>
+public sealed record FlagDisabled(string FlagName, EnvironmentType Environment, string UserId)
+    : EvaluationResult(FlagName, Environment, UserId, EvaluationReason.FlagDisabled);
+
+/// <summary>
+/// The flag is enabled and a rollout strategy produced the final decision.
+/// </summary>
+public sealed record StrategyEvaluated(
+    string FlagName,
+    EnvironmentType Environment,
+    string UserId,
+    bool IsEnabled,
+    RolloutStrategy StrategyType
+) : EvaluationResult(FlagName, Environment, UserId, EvaluationReason.StrategyEvaluated);

--- a/FeatureFlag.Application/Services/FeatureFlagService.cs
+++ b/FeatureFlag.Application/Services/FeatureFlagService.cs
@@ -1,3 +1,6 @@
+using System.Diagnostics;
+using System.Security.Cryptography;
+using System.Text;
 using FeatureFlag.Application.DTOs;
 using FeatureFlag.Application.Evaluation;
 using FeatureFlag.Application.Interfaces;
@@ -7,6 +10,7 @@ using FeatureFlag.Domain.Enums;
 using FeatureFlag.Domain.Exceptions;
 using FeatureFlag.Domain.Interfaces;
 using FeatureFlag.Domain.ValueObjects;
+using Microsoft.Extensions.Logging;
 
 namespace FeatureFlag.Application.Services;
 
@@ -14,11 +18,17 @@ public sealed class FeatureFlagService : IFeatureFlagService
 {
     private readonly IFeatureFlagRepository _repository;
     private readonly FeatureEvaluator _evaluator;
+    private readonly ILogger<FeatureFlagService> _logger;
 
-    public FeatureFlagService(IFeatureFlagRepository repository, FeatureEvaluator evaluator)
+    public FeatureFlagService(
+        IFeatureFlagRepository repository,
+        FeatureEvaluator evaluator,
+        ILogger<FeatureFlagService> logger
+    )
     {
         _repository = repository;
         _evaluator = evaluator;
+        _logger = logger;
     }
 
     public async Task<FlagResponse> GetFlagAsync(
@@ -51,16 +61,43 @@ public sealed class FeatureFlagService : IFeatureFlagService
             environment: context.Environment
         );
 
-        Flag flag =
-            await _repository.GetByNameAsync(flagName, sanitizedContext.Environment, ct)
-            ?? throw new FlagNotFoundException(flagName);
+        Flag? flag = await _repository.GetByNameAsync(flagName, sanitizedContext.Environment, ct);
+
+        if (flag is null)
+        {
+            _logger.LogWarning(
+                "Flag evaluation: not found. Flag={FlagName} Environment={Environment}",
+                flagName,
+                sanitizedContext.Environment
+            );
+
+            throw new FlagNotFoundException(flagName);
+        }
 
         if (!flag.IsEnabled)
         {
+            var result = new FlagDisabled(
+                FlagName: flagName,
+                Environment: sanitizedContext.Environment,
+                UserId: sanitizedContext.UserId
+            );
+
+            LogResult(result);
             return false;
         }
 
-        return _evaluator.Evaluate(flag, sanitizedContext);
+        bool isEnabled = _evaluator.Evaluate(flag, sanitizedContext);
+
+        var strategyResult = new StrategyEvaluated(
+            FlagName: flagName,
+            Environment: sanitizedContext.Environment,
+            UserId: sanitizedContext.UserId,
+            IsEnabled: isEnabled,
+            StrategyType: flag.StrategyType
+        );
+
+        LogResult(strategyResult);
+        return isEnabled;
     }
 
     public async Task<IReadOnlyList<FlagResponse>> GetAllFlagsAsync(
@@ -134,5 +171,61 @@ public sealed class FeatureFlagService : IFeatureFlagService
 
         flag.Archive();
         await _repository.SaveChangesAsync(ct);
+    }
+
+    /// <summary>
+    /// Writes a structured log entry for a completed evaluation outcome.
+    /// UserId is hashed to a short SHA256 surrogate and never logged raw.
+    /// Each branch logs only the fields meaningful to that outcome.
+    /// </summary>
+    private void LogResult(EvaluationResult result)
+    {
+        if (!_logger.IsEnabled(LogLevel.Information))
+        {
+            return;
+        }
+
+        switch (result)
+        {
+            case FlagDisabled d:
+                _logger.LogInformation(
+                    "Flag evaluation complete. Flag={FlagName} Environment={Environment} "
+                        + "UserId={UserId} Reason={Reason}",
+                    d.FlagName,
+                    d.Environment,
+                    HashUserId(d.UserId),
+                    d.Reason
+                );
+                break;
+
+            case StrategyEvaluated s:
+                _logger.LogInformation(
+                    "Flag evaluation complete. Flag={FlagName} Environment={Environment} "
+                        + "UserId={UserId} Reason={Reason} Result={Result} Strategy={StrategyType}",
+                    s.FlagName,
+                    s.Environment,
+                    HashUserId(s.UserId),
+                    s.Reason,
+                    s.IsEnabled ? "enabled" : "disabled",
+                    s.StrategyType
+                );
+                break;
+
+            default:
+                throw new UnreachableException(
+                    $"Unhandled EvaluationResult subtype: {result.GetType().Name}. "
+                        + "Add a logging branch for every new EvaluationResult subtype."
+                );
+        }
+    }
+
+    /// <summary>
+    /// Returns a short deterministic SHA256 fingerprint of the raw UserId.
+    /// Deterministic output enables correlation without logging the original value.
+    /// </summary>
+    private static string HashUserId(string userId)
+    {
+        byte[] bytes = SHA256.HashData(Encoding.UTF8.GetBytes(userId));
+        return Convert.ToHexString(bytes)[..8].ToLowerInvariant();
     }
 }

--- a/FeatureFlag.Application/packages.lock.json
+++ b/FeatureFlag.Application/packages.lock.json
@@ -1,0 +1,22 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net10.0": {
+      "FluentValidation": {
+        "type": "Direct",
+        "requested": "[12.*, )",
+        "resolved": "12.1.1",
+        "contentHash": "EPpkIe1yh1a0OXyC100oOA8WMbZvqUu5plwhvYcb7oSELfyUZzfxV48BLhvs3kKo4NwG7MGLNgy1RJiYtT8Dpw=="
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Direct",
+        "requested": "[10.0.5, )",
+        "resolved": "10.0.5",
+        "contentHash": "iVMtq9eRvzyhx8949EGT0OCYJfXi737SbRVzWXE5GrOgGj5AaZ9eUuxA/BSUfmOMALKn/g8KfFaNQw0eiB3lyA=="
+      },
+      "featureflag.domain": {
+        "type": "Project"
+      }
+    }
+  }
+}

--- a/FeatureFlag.Domain/packages.lock.json
+++ b/FeatureFlag.Domain/packages.lock.json
@@ -1,0 +1,6 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net10.0": {}
+  }
+}

--- a/FeatureFlag.Infrastructure/packages.lock.json
+++ b/FeatureFlag.Infrastructure/packages.lock.json
@@ -1,0 +1,320 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net10.0": {
+      "Microsoft.EntityFrameworkCore.Design": {
+        "type": "Direct",
+        "requested": "[10.0.4, )",
+        "resolved": "10.0.4",
+        "contentHash": "FmiUU5xdu1chVxnmsu/mEpCKVQ5+lvIxdP0194lE7HfoU1jO4z/9qnWZpd0kSkVve4gOnRm1lE20kkhlMqJJIg==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.Build.Framework": "18.0.2",
+          "Microsoft.CodeAnalysis.CSharp": "5.0.0",
+          "Microsoft.CodeAnalysis.CSharp.Workspaces": "5.0.0",
+          "Microsoft.CodeAnalysis.Workspaces.MSBuild": "5.0.0",
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.4",
+          "Microsoft.Extensions.Caching.Memory": "10.0.4",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.4",
+          "Microsoft.Extensions.DependencyModel": "10.0.4",
+          "Microsoft.Extensions.Logging": "10.0.4",
+          "Mono.TextTemplating": "3.0.0",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Direct",
+        "requested": "[10.0.5, )",
+        "resolved": "10.0.5",
+        "contentHash": "P09QpTHjqHmCLQOTC+WyLkoRNxek4NIvfWt+TnU0etoDUSRxcltyd6+j/ouRbMdLR0j44GqGO+lhI2M4fAHG4g==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Direct",
+        "requested": "[10.0.5, )",
+        "resolved": "10.0.5",
+        "contentHash": "iVMtq9eRvzyhx8949EGT0OCYJfXi737SbRVzWXE5GrOgGj5AaZ9eUuxA/BSUfmOMALKn/g8KfFaNQw0eiB3lyA=="
+      },
+      "Npgsql.EntityFrameworkCore.PostgreSQL": {
+        "type": "Direct",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "P6EwH0Q4xkaA264iNZDqCPhWt8pscfUGxXazDQg4noBfqjoOlk4hKWfvBjF9ZX3R/9JybRmmJfmxr2iBMj0EpA==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "[10.0.4, 11.0.0)",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.0.4, 11.0.0)",
+          "Npgsql": "10.0.2"
+        }
+      },
+      "FluentValidation": {
+        "type": "Transitive",
+        "resolved": "12.1.1",
+        "contentHash": "EPpkIe1yh1a0OXyC100oOA8WMbZvqUu5plwhvYcb7oSELfyUZzfxV48BLhvs3kKo4NwG7MGLNgy1RJiYtT8Dpw=="
+      },
+      "Humanizer.Core": {
+        "type": "Transitive",
+        "resolved": "2.14.1",
+        "contentHash": "lQKvtaTDOXnoVJ20ibTuSIOf2i0uO0MPbDhd1jm238I+U/2ZnRENj0cktKZhtchBMtCUSRQ5v4xBCUbKNmyVMw=="
+      },
+      "Microsoft.Build.Framework": {
+        "type": "Transitive",
+        "resolved": "18.0.2",
+        "contentHash": "sOSb+0J4G/jCBW/YqmRuL0eOMXgfw1KQLdC9TkbvfA5xs7uNm+PBQXJCOzSJGXtZcZrtXozcwxPmUiRUbmd7FA=="
+      },
+      "Microsoft.CodeAnalysis.Analyzers": {
+        "type": "Transitive",
+        "resolved": "3.11.0",
+        "contentHash": "v/EW3UE8/lbEYHoC2Qq7AR/DnmvpgdtAMndfQNmpuIMx/Mto8L5JnuCfdBYtgvalQOtfNCnxFejxuRrryvUTsg=="
+      },
+      "Microsoft.CodeAnalysis.Common": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "ZXRAdvH6GiDeHRyd3q/km8Z44RoM6FBWHd+gen/la81mVnAdHTEsEkO5J0TCNXBymAcx5UYKt5TvgKBhaLJEow==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.CSharp": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "5DSyJ9bk+ATuDy7fp2Zt0mJStDVKbBoiz1DyfAwSa+k4H4IwykAUcV3URelw5b8/iVbfSaOwkwmPUZH6opZKCw==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]"
+        }
+      },
+      "Microsoft.CodeAnalysis.CSharp.Workspaces": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "Al/Q8B+yO8odSqGVpSvrShMFDvlQdIBU//F3E6Rb0YdiLSALE9wh/pvozPNnfmh5HDnvU+mkmSjpz4hQO++jaA==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.CSharp": "[5.0.0]",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]",
+          "Microsoft.CodeAnalysis.Workspaces.Common": "[5.0.0]",
+          "System.Composition": "9.0.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.Workspaces.Common": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "ZbUmIvT6lqTNKiv06Jl5wf0MTMi1vQ1oH7ou4CLcs2C/no/L7EhP3T8y3XXvn9VbqMcJaJnEsNA1jwYUMgc5jg==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]",
+          "System.Composition": "9.0.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.Workspaces.MSBuild": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "/G+LVoAGMz6Ae8nm+PGLxSw+F5RjYx/J7irbTO5uKAPw1bxHyQJLc/YOnpDxt+EpPtYxvC9wvBsg/kETZp1F9Q==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.Build.Framework": "17.11.31",
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Workspaces.Common": "[5.0.0]",
+          "Microsoft.Extensions.DependencyInjection": "9.0.0",
+          "Microsoft.Extensions.Logging": "9.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.0",
+          "Microsoft.Extensions.Options": "9.0.0",
+          "Microsoft.Extensions.Primitives": "9.0.0",
+          "Microsoft.VisualStudio.SolutionPersistence": "1.0.52",
+          "Newtonsoft.Json": "13.0.3",
+          "System.Composition": "9.0.0"
+        }
+      },
+      "Microsoft.EntityFrameworkCore": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "kzTsfFK2GCytp6DDTfQOmxPU4gbGdrIlP7PxrxF3ESNLtfXrC8BoUVZENBN2WORlZPAD7CVX6AYIglgkpXQooA==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.4",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.4",
+          "Microsoft.Extensions.Caching.Memory": "10.0.4",
+          "Microsoft.Extensions.Logging": "10.0.4"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "qDcJqCfN1XYyX0ID/Hd9/kQTRvlia8S+Yuwyl9uFhBIKnOCbl9WMdGQCzbZUKbkpkfvf3P9CDdXsnxHyE3O0Aw=="
+      },
+      "Microsoft.EntityFrameworkCore.Analyzers": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "pQeMHCyD3yTtCEGnHV4VsgKUvrESo3MR5mnh8sgQ1hWYmI1YFsUutDowBIxkobeWRtaRmBqQAtF7XQFW6FWuNA=="
+      },
+      "Microsoft.EntityFrameworkCore.Relational": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "DOTjTHy93W3TwpMLM4SCm0n57Sc0Jj3+m2S6LSTstKyBB34eT1UouaMS19mpWwvtj42+sRiEjA3+rOTNoNzXFQ==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "10.0.4",
+          "Microsoft.Extensions.Caching.Memory": "10.0.4",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.4",
+          "Microsoft.Extensions.Logging": "10.0.4"
+        }
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "uDRooaV6N3WZ0kdlNPMB68/MdGn/in1Fs7Db7DnIm85RBTPy4P321WO+daAImiYpH5dekjNggDqy1N44WaIlMA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.4"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "CLLussNUMdSbyJOu4VBF7sqskHGB/5N1EcFzrqG/HsPATN8fCRUcfp0qns1VwkxKHwxrtYCh5FKe+kM81Q1PHA==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.4",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.4",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.4",
+          "Microsoft.Extensions.Options": "10.0.4",
+          "Microsoft.Extensions.Primitives": "10.0.4"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "NkvJ8aSr3AG30yabjv7ZWwTG/wq5OElNTlNq39Ok2HSEF3TIwAc1f1xnTJlR/GuoJmEgkfT7WBO9YbSXRk41+g==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.4"
+        }
+      },
+      "Microsoft.Extensions.DependencyModel": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "LiJXylfk8pk+2zsUsITkou3QTFMJ8RNJ0oKKY0Oyjt6HJctGJwPw//ZgoNO4J29zKaT+dR4/PI2jW/znRcspLg=="
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "S8+6fCuMOhJZGk8sGFtOy3VsF9mk9x4UOL59GM91REiA/fmCDjunKKIw4RmStG87qyXPfxelDJf2pXIbTuaBdw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "10.0.4",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.4",
+          "Microsoft.Extensions.Options": "10.0.4"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "PDMMt7fvBatv6hcxxyJtXIzSwn7Dy00W6I2vDAOTYrQqNM2dF5A2L9n0uMzdPz2IPoNZWkAmYjoOCEdDLq0i4w==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.4"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "kRxa2Zjzhg/ohh7EklpqQpBIcyQnC3meWxCcpZBn+0QWy/fY1DmDd45JiW8Vyrpj2J1RDtau5yRHiLZS/AoxUw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.4",
+          "Microsoft.Extensions.Primitives": "10.0.4"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "/HUHJ0tw/LQvD0DZrz50eQy/3z7PfX7WWEaXnjKTV9/TNdcgFlNTZGo49QhS7PTmhDqMyHRMqAXSBxLh0vso4g=="
+      },
+      "Microsoft.VisualStudio.SolutionPersistence": {
+        "type": "Transitive",
+        "resolved": "1.0.52",
+        "contentHash": "oNv2JtYXhpdJrX63nibx1JT3uCESOBQ1LAk7Dtz/sr0+laW0KRM6eKp4CZ3MHDR2siIkKsY8MmUkeP5DKkQQ5w=="
+      },
+      "Mono.TextTemplating": {
+        "type": "Transitive",
+        "resolved": "3.0.0",
+        "contentHash": "YqueG52R/Xej4VVbKuRIodjiAhV0HR/XVbLbNrJhCZnzjnSjgMJ/dCdV0akQQxavX6hp/LC6rqLGLcXeQYU7XA==",
+        "dependencies": {
+          "System.CodeDom": "6.0.0"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "Npgsql": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "q5RfBI+wywJSFUNDE1L4ZbHEHCFTblo8Uf6A6oe4feOUFYiUQXyAf9GBh5qEZpvJaHiEbpBPkQumjEhXCJxdrg==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
+        }
+      },
+      "System.CodeDom": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "CPc6tWO1LAer3IzfZufDBRL+UZQcj5uS207NHALQzP84Vp/z6wF0Aa0YZImOQY8iStY0A2zI/e3ihKNPfUm8XA=="
+      },
+      "System.Composition": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "3Djj70fFTraOarSKmRnmRy/zm4YurICm+kiCtI0dYRqGJnLX6nJ+G3WYuFJ173cAPax/gh96REcbNiVqcrypFQ==",
+        "dependencies": {
+          "System.Composition.AttributedModel": "9.0.0",
+          "System.Composition.Convention": "9.0.0",
+          "System.Composition.Hosting": "9.0.0",
+          "System.Composition.Runtime": "9.0.0",
+          "System.Composition.TypedParts": "9.0.0"
+        }
+      },
+      "System.Composition.AttributedModel": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "iri00l/zIX9g4lHMY+Nz0qV1n40+jFYAmgsaiNn16xvt2RDwlqByNG4wgblagnDYxm3YSQQ0jLlC/7Xlk9CzyA=="
+      },
+      "System.Composition.Convention": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "+vuqVP6xpi582XIjJi6OCsIxuoTZfR0M7WWufk3uGDeCl3wGW6KnpylUJ3iiXdPByPE0vR5TjJgR6hDLez4FQg==",
+        "dependencies": {
+          "System.Composition.AttributedModel": "9.0.0"
+        }
+      },
+      "System.Composition.Hosting": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "OFqSeFeJYr7kHxDfaViGM1ymk7d4JxK//VSoNF9Ux0gpqkLsauDZpu89kTHHNdCWfSljbFcvAafGyBoY094btQ==",
+        "dependencies": {
+          "System.Composition.Runtime": "9.0.0"
+        }
+      },
+      "System.Composition.Runtime": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "w1HOlQY1zsOWYussjFGZCEYF2UZXgvoYnS94NIu2CBnAGMbXFAX8PY8c92KwUItPmowal68jnVLBCzdrWLeEKA=="
+      },
+      "System.Composition.TypedParts": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "aRZlojCCGEHDKqh43jaDgaVpYETsgd7Nx4g1zwLKMtv4iTo0627715ajEFNpEEBTgLmvZuv8K0EVxc3sM4NWJA==",
+        "dependencies": {
+          "System.Composition.AttributedModel": "9.0.0",
+          "System.Composition.Hosting": "9.0.0",
+          "System.Composition.Runtime": "9.0.0"
+        }
+      },
+      "featureflag.application": {
+        "type": "Project",
+        "dependencies": {
+          "FeatureFlag.Domain": "[1.0.0, )",
+          "FluentValidation": "[12.*, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.5, )"
+        }
+      },
+      "featureflag.domain": {
+        "type": "Project"
+      }
+    }
+  }
+}

--- a/FeatureFlag.Tests.Integration/packages.lock.json
+++ b/FeatureFlag.Tests.Integration/packages.lock.json
@@ -1,0 +1,594 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net10.0": {
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[8.0.1, )",
+        "resolved": "8.0.1",
+        "contentHash": "heVQl5tKYnnIDYlR1QMVGueYH6iriZTcZB6AjDczQNwZzxkjDIt9C84Pt4cCiZYrbo7jkZOYGWbs6Lo9wAtVLg=="
+      },
+      "FluentAssertions": {
+        "type": "Direct",
+        "requested": "[8.9.0, )",
+        "resolved": "8.9.0",
+        "contentHash": "Y5RDjxaVlxWX2yy0X/ay1tJjSKMOtjepSb83mmfngFS63hm3LsoZNj6nhmImzm1ifRmpF9ouvmHjx9nNwnkpDg=="
+      },
+      "Microsoft.AspNetCore.Mvc.Testing": {
+        "type": "Direct",
+        "requested": "[10.0.5, )",
+        "resolved": "10.0.5",
+        "contentHash": "MfacYQ7jNzj6073YobyoFfXpNmGqrV1UCywTM339DOcYpfalcM4K4heFjV5k3dDkKkWOGWO/DV3hdmVRqFkIxA==",
+        "dependencies": {
+          "Microsoft.AspNetCore.TestHost": "10.0.5",
+          "Microsoft.Extensions.DependencyModel": "10.0.5",
+          "Microsoft.Extensions.Hosting": "10.0.5"
+        }
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[18.4.0, )",
+        "resolved": "18.4.0",
+        "contentHash": "w49iZdL4HL6V25l41NVQLXWQ+e71GvSkKVteMrOL02gP/PUkcnO/1yEb2s9FntU4wGmJWfKnyrRAhcMHd9ZZNA==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "18.4.0",
+          "Microsoft.TestPlatform.TestHost": "18.4.0"
+        }
+      },
+      "Testcontainers.PostgreSql": {
+        "type": "Direct",
+        "requested": "[4.11.0, )",
+        "resolved": "4.11.0",
+        "contentHash": "OWGi0Og+qFpr2OPDignA74aJSfUd0nvZOaXNGWXwMJR1BvpdzhCNHQB2h7yLSTb0a8JVmmQQ4mUpHAC9q27NLw==",
+        "dependencies": {
+          "Testcontainers": "4.11.0"
+        }
+      },
+      "xunit": {
+        "type": "Direct",
+        "requested": "[2.9.3, )",
+        "resolved": "2.9.3",
+        "contentHash": "TlXQBinK35LpOPKHAqbLY4xlEen9TBafjs0V5KnA4wZsoQLQJiirCR4CbIXvOH8NzkW4YeJKP5P/Bnrodm0h9Q==",
+        "dependencies": {
+          "xunit.analyzers": "1.18.0",
+          "xunit.assert": "2.9.3",
+          "xunit.core": "[2.9.3]"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[3.1.5, )",
+        "resolved": "3.1.5",
+        "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
+      },
+      "BouncyCastle.Cryptography": {
+        "type": "Transitive",
+        "resolved": "2.6.2",
+        "contentHash": "7oWOcvnntmMKNzDLsdxAYqApt+AjpRpP2CShjMfIa3umZ42UQMvH0tl1qAliYPNYO6vTdcGMqnRrCPmsfzTI1w=="
+      },
+      "Docker.DotNet.Enhanced": {
+        "type": "Transitive",
+        "resolved": "3.131.1",
+        "contentHash": "hGLHCNUsQbT2Ab/HUznRnNqYZQs40zInXa3eLwYjeNyfUYbw1pqqDGqcOLl5uGepS8IuigEYakEdAcVT/2ezYg==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3"
+        }
+      },
+      "Docker.DotNet.Enhanced.X509": {
+        "type": "Transitive",
+        "resolved": "3.131.1",
+        "contentHash": "8FU7zmttFQzp0xb0EPupxQ0nGtC2cTpukgh3jMxMT8luj5TSDyzIKTnroDpXCjpg9P2fV+6JIvC+IetsMEfyBA==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced": "3.131.1"
+        }
+      },
+      "FluentValidation": {
+        "type": "Transitive",
+        "resolved": "12.1.1",
+        "contentHash": "EPpkIe1yh1a0OXyC100oOA8WMbZvqUu5plwhvYcb7oSELfyUZzfxV48BLhvs3kKo4NwG7MGLNgy1RJiYtT8Dpw=="
+      },
+      "Microsoft.AspNetCore.OpenApi": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "vTcxIfOPyfFbYk1g8YcXJfkMnlEWVkSnnjxcZLy60zgwiHMRf2SnZR+9E4HlpwKxgE3yfKMOti8J6WfKuKsw6w==",
+        "dependencies": {
+          "Microsoft.OpenApi": "2.0.0"
+        }
+      },
+      "Microsoft.AspNetCore.TestHost": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "PJEdrZnnhvxIEXzDdvdZ38GvpdaiUfKkZ99kudS8riJwhowFb/Qh26Wjk9smrCWcYdMFQmpN5epGiL4o1s8LYA=="
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "18.4.0",
+        "contentHash": "9O0BtCfzCWrkAmK187ugKdq72HHOXoOUjuWFDVc2LsZZ0pOnA9bTt+Sg9q4cF+MoAaUU+MuWtvBuFsnduviJow=="
+      },
+      "Microsoft.EntityFrameworkCore": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "kzTsfFK2GCytp6DDTfQOmxPU4gbGdrIlP7PxrxF3ESNLtfXrC8BoUVZENBN2WORlZPAD7CVX6AYIglgkpXQooA==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.4",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.4",
+          "Microsoft.Extensions.Caching.Memory": "10.0.4",
+          "Microsoft.Extensions.Logging": "10.0.4"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "qDcJqCfN1XYyX0ID/Hd9/kQTRvlia8S+Yuwyl9uFhBIKnOCbl9WMdGQCzbZUKbkpkfvf3P9CDdXsnxHyE3O0Aw=="
+      },
+      "Microsoft.EntityFrameworkCore.Analyzers": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "pQeMHCyD3yTtCEGnHV4VsgKUvrESo3MR5mnh8sgQ1hWYmI1YFsUutDowBIxkobeWRtaRmBqQAtF7XQFW6FWuNA=="
+      },
+      "Microsoft.EntityFrameworkCore.Relational": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "DOTjTHy93W3TwpMLM4SCm0n57Sc0Jj3+m2S6LSTstKyBB34eT1UouaMS19mpWwvtj42+sRiEjA3+rOTNoNzXFQ==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "10.0.4",
+          "Microsoft.Extensions.Caching.Memory": "10.0.4",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.4",
+          "Microsoft.Extensions.Logging": "10.0.4"
+        }
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "uDRooaV6N3WZ0kdlNPMB68/MdGn/in1Fs7Db7DnIm85RBTPy4P321WO+daAImiYpH5dekjNggDqy1N44WaIlMA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.4"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "CLLussNUMdSbyJOu4VBF7sqskHGB/5N1EcFzrqG/HsPATN8fCRUcfp0qns1VwkxKHwxrtYCh5FKe+kM81Q1PHA==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.4",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.4",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.4",
+          "Microsoft.Extensions.Options": "10.0.4",
+          "Microsoft.Extensions.Primitives": "10.0.4"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "8Rx5sqg04FttxrumyG6bmoRuFRgYzK6IVwF1i0/o0cXfKBdDeVpJejKHtJCMjyg9E/DNMVqpqOGe/tCT5gYvVA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "P09QpTHjqHmCLQOTC+WyLkoRNxek4NIvfWt+TnU0etoDUSRxcltyd6+j/ouRbMdLR0j44GqGO+lhI2M4fAHG4g==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "99Z4rjyXopb1MIazDSPcvwYCUdYNO01Cf1GUs2WUjIFAbkGmwzj2vPa2k+3pheJRV+YgNd2QqRKHAri0oBAU4Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.5",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Configuration.CommandLine": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "or9fOLopMUTJOQVJ3bou4aD6PwvsiKf4kZC4EE5sRRKSkmh+wfk/LekJXRjAX88X+1JA9zHjDo+5fiQ7z3MY/A==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.5",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Configuration.EnvironmentVariables": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "tchMGQ+zVTO40np/Zzg2Li/TIR8bksQgg4UVXZa0OzeFCKWnIYtxE2FVs+eSmjPGCjMS2voZbwN/mUcYfpSTuA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.5",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Configuration.FileExtensions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "OhTr0O79dP49734lLTqVveivVX9sDXxbI/8vjELAZTHXqoN90mdpgTAgwicJED42iaHMCcZcK6Bj+8wNyBikaw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.5",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.5",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Json": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "brBM/WP0YAUYh2+QqSYVdK8eQHYQTtTEUJXJ+84Zkdo2buGLja9VSrMIhgoeBUU7JBmcskAib8Lb/N83bvxgYQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.5",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.5",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Configuration.UserSecrets": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "fhdG6UV9lIp70QhNkVyaHciUVq25IPFkczheVJL9bIFvmnJ+Zghaie6dWkDbbVmxZlHl9gj3zTDxMxJs5zNhIA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Configuration.Json": "10.0.5",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.5",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "v1SVsowG6YE1YnHVGmLWz57YTRCQRx9pH5ebIESXfm5isI9gA3QaMyg/oMTzPpXYZwSAVDzYItGJKfmV+pqXkQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "iVMtq9eRvzyhx8949EGT0OCYJfXi737SbRVzWXE5GrOgGj5AaZ9eUuxA/BSUfmOMALKn/g8KfFaNQw0eiB3lyA=="
+      },
+      "Microsoft.Extensions.DependencyModel": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "xA4kkL+QS6KCAOKz/O0oquHs44Ob8J7zpBCNt3wjkBWDg5aCqfwG8rWWLsg5V86AM0sB849g9JjPjIdksTCIKg=="
+      },
+      "Microsoft.Extensions.Diagnostics": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "vAJHd4yOpmKoK+jBuYV7a3y+Ab9U4ARCc29b6qvMy276RgJFw9LFs0DdsPqOL3ahwzyrX7tM+i4cCxU/RX0qAg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.5",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "/nYGrpa9/0BZofrVpBbbj+Ns8ZesiPE0V/KxsuHgDgHQopIzN54nRaQGSuvPw16/kI9sW1Zox5yyAPqvf0Jz6A==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "nCBmCx0Xemlu65ZiWMcXbvfvtznKxf4/YYKF9R28QkqdI9lTikedGqzJ28/xmdGGsxUnsP5/3TQGpiPwVjK0dA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Physical": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "dMu5kUPSfol1Rqhmr6nWPSmbFjDe9w6bkoKithG17bWTZA0UyKirTatM5mqYUN3mGpNA0MorlusIoVTh6J7o5g==",
+        "dependencies": {
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.5",
+          "Microsoft.Extensions.FileSystemGlobbing": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.FileSystemGlobbing": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "mOE3ARusNQR0a5x8YOcnUbfyyXGqoAWQtEc7qFOfNJgruDWQLo39Re+3/Lzj5pLPFuFYj8hN4dgKzaSQDKiOCw=="
+      },
+      "Microsoft.Extensions.Hosting": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "8i7e5IBdiKLNqt/+ciWrS8U95Rv5DClaaj7ulkZbimnCi4uREWd+lXzkp3joofFuIPOlAzV4AckxLTIELv2jdg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.5",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.5",
+          "Microsoft.Extensions.Configuration.CommandLine": "10.0.5",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "10.0.5",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.5",
+          "Microsoft.Extensions.Configuration.Json": "10.0.5",
+          "Microsoft.Extensions.Configuration.UserSecrets": "10.0.5",
+          "Microsoft.Extensions.DependencyInjection": "10.0.5",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Diagnostics": "10.0.5",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.5",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.5",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Logging": "10.0.5",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.5",
+          "Microsoft.Extensions.Logging.Console": "10.0.5",
+          "Microsoft.Extensions.Logging.Debug": "10.0.5",
+          "Microsoft.Extensions.Logging.EventLog": "10.0.5",
+          "Microsoft.Extensions.Logging.EventSource": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "+Wb7KAMVZTomwJkQrjuPTe5KBzGod7N8XeG+ScxRlkPOB4sZLG4ccVwjV4Phk5BCJt7uIMnGHVoN6ZMVploX+g==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.5",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "+XTMKQyDWg4ODoNHU/BN3BaI1jhGO7VCS+BnzT/4IauiG6y2iPAte7MyD7rHKS+hNP0TkFkjrae8DFjDUxtcxg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "10.0.5",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "9HOdqlDtPptVcmKAjsQ/Nr5Rxfq6FMYLdhvZh1lVmeKR738qeYecQD7+ldooXf+u2KzzR1kafSphWngIM3C6ug==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Logging.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "cSgxsDgfP0+gmVRPVoNHI/KIDavIZxh+CxE6tSLPlYTogqccDnjBFI9CgEsiNuMP6+fiuXUwhhlTz36uUEpwbQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.5",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.5",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Logging": "10.0.5",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Logging.Console": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "PMs2gha2v24hvH5o5KQem5aNK4mN0BhhCWlMqsg9tzifWKzjeQi2tyPOP/RaWMVvalOhVLcrmoMYPqbnia/epg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Logging": "10.0.5",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Logging.Debug": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "/VacEkBQ02A8PBXSa6YpbIXCuisYy6JJr62/+ANJDZE+RMBfZMcXJXLfr/LpyLE6pgdp17Wxlt7e7R9zvkwZ3Q==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Logging": "10.0.5",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Logging.EventLog": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "0ezhWYJS4/6KrqQel9JL+Tr4n+4EX2TF5EYiaysBWNNEM2c3Gtj1moD39esfgk8OHblSX+UFjtZ3z0c4i9tRvw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Logging": "10.0.5",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5",
+          "System.Diagnostics.EventLog": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Logging.EventSource": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "vN+aq1hBFXyYvY5Ow9WyeR66drKQxRZmas4lAjh6QWfryPkjTn1uLtX5AFIxyDaZj78v5TG2sELUyvrXpAPQQw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Logging": "10.0.5",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "MDaQMdUplw0AIRhWWmbLA7yQEXaLIHb+9CTroTiNS8OlI0LMXS4LCxtopqauiqGCWlRgJ+xyraVD8t6veRAFbw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "BB9uUW3+6Rxu1R97OB1H/13lUF8P2+H1+eDhpZlK30kDh/6E4EKHBUqTp+ilXQmZLzsRErxON8aBSR6WpUKJdg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.5",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5",
+          "Microsoft.Extensions.Options": "10.0.5",
+          "Microsoft.Extensions.Primitives": "10.0.5"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "/HUHJ0tw/LQvD0DZrz50eQy/3z7PfX7WWEaXnjKTV9/TNdcgFlNTZGo49QhS7PTmhDqMyHRMqAXSBxLh0vso4g=="
+      },
+      "Microsoft.OpenApi": {
+        "type": "Transitive",
+        "resolved": "2.0.0",
+        "contentHash": "GGYLfzV/G/ct80OZ45JxnWP7NvMX1BCugn/lX7TH5o0lcVaviavsLMTxmFV2AybXWjbi3h6FF1vgZiTK6PXndw=="
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "18.4.0",
+        "contentHash": "4L6m2kS2pY5uJ9cpeRxzW22opr6ttScIRqsOpMDQpgENp/ZwxkkQCcmc6LRSURo2dFaaSW5KVflQZvroiJ7Wzg=="
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "18.4.0",
+        "contentHash": "gZsCHI+zOmZCcKZieIL4Jg14qKD2OGZOmX5DehuIk1EA9BN6Crm0+taXQNEuajOH1G9CCyBxw8VWR4t5tumcng==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "18.4.0",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "Npgsql": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "q5RfBI+wywJSFUNDE1L4ZbHEHCFTblo8Uf6A6oe4feOUFYiUQXyAf9GBh5qEZpvJaHiEbpBPkQumjEhXCJxdrg==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
+        }
+      },
+      "Npgsql.EntityFrameworkCore.PostgreSQL": {
+        "type": "Transitive",
+        "resolved": "10.0.1",
+        "contentHash": "P6EwH0Q4xkaA264iNZDqCPhWt8pscfUGxXazDQg4noBfqjoOlk4hKWfvBjF9ZX3R/9JybRmmJfmxr2iBMj0EpA==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "[10.0.4, 11.0.0)",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.0.4, 11.0.0)",
+          "Npgsql": "10.0.2"
+        }
+      },
+      "Scalar.AspNetCore": {
+        "type": "Transitive",
+        "resolved": "2.13.20",
+        "contentHash": "KLWQcH0YisMa0nzv36S5TcKgZ5seAaTHXVcdG8S3H0UFFtAeBYwSOnzme6S9Ch1Tl9trpa0G8aiCjzF9H9khTw=="
+      },
+      "SharpZipLib": {
+        "type": "Transitive",
+        "resolved": "1.4.2",
+        "contentHash": "yjj+3zgz8zgXpiiC3ZdF/iyTBbz2fFvMxZFEBPUcwZjIvXOf37Ylm+K58hqMfIBt5JgU/Z2uoUS67JmTLe973A=="
+      },
+      "SSH.NET": {
+        "type": "Transitive",
+        "resolved": "2025.1.0",
+        "contentHash": "jrnbtf0ItVaXAe6jE8X/kSLa6uC+0C+7W1vepcnRQB/rD88qy4IxG7Lf1FIbWmkoc4iVXv0pKrz+Wc6J4ngmHw==",
+        "dependencies": {
+          "BouncyCastle.Cryptography": "2.6.2",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3"
+        }
+      },
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "wugvy+pBVzjQEnRs9wMTWwoaeNFX3hsaHeVHFDIvJSWXp7wfmNWu3mxAwBIE6pyW+g6+rHa1Of5fTzb0QVqUTA=="
+      },
+      "Testcontainers": {
+        "type": "Transitive",
+        "resolved": "4.11.0",
+        "contentHash": "9pBNaK9Ra3GVnr5h6gaDJOBH0txA5G3Juho5WANPuyu38l5xyr2lCvf11oA5/uSd+Lh4Wtng34nKp3nMiea02g==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced": "3.131.1",
+          "Docker.DotNet.Enhanced.X509": "3.131.1",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
+          "SSH.NET": "2025.1.0",
+          "SharpZipLib": "1.4.2"
+        }
+      },
+      "xunit.abstractions": {
+        "type": "Transitive",
+        "resolved": "2.0.3",
+        "contentHash": "pot1I4YOxlWjIb5jmwvvQNbTrZ3lJQ+jUGkGjWE3hEFM0l5gOnBWS+H3qsex68s5cO52g+44vpGzhAt+42vwKg=="
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.18.0",
+        "contentHash": "OtFMHN8yqIcYP9wcVIgJrq01AfTxijjAqVDy/WeQVSyrDC1RzBWeQPztL49DN2syXRah8TYnfvk035s7L95EZQ=="
+      },
+      "xunit.assert": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "/Kq28fCE7MjOV42YLVRAJzRF0WmEqsmflm0cfpMjGtzQ2lR5mYVj1/i0Y8uDAOLczkL3/jArrwehfMD0YogMAA=="
+      },
+      "xunit.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "BiAEvqGvyme19wE0wTKdADH+NloYqikiU0mcnmiNyXaF9HyHmE6sr/3DC5vnBkgsWaE6yPyWszKSPSApWdRVeQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]",
+          "xunit.extensibility.execution": "[2.9.3]"
+        }
+      },
+      "xunit.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "kf3si0YTn2a8J8eZNb+zFpwfoyvIrQ7ivNk5ZYA5yuYk1bEtMe4DxJ2CF/qsRgmEnDr7MnW1mxylBaHTZ4qErA==",
+        "dependencies": {
+          "xunit.abstractions": "2.0.3"
+        }
+      },
+      "xunit.extensibility.execution": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "yMb6vMESlSrE3Wfj7V6cjQ3S4TXdXpRqYeNEI3zsX31uTsGMJjEw6oD5F5u1cHnMptjhEECnmZSsPxB6ChZHDQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]"
+        }
+      },
+      "featureflag.api": {
+        "type": "Project",
+        "dependencies": {
+          "FeatureFlag.Application": "[1.0.0, )",
+          "FeatureFlag.Infrastructure": "[1.0.0, )",
+          "Microsoft.AspNetCore.OpenApi": "[10.0.5, )",
+          "Scalar.AspNetCore": "[2.*, )"
+        }
+      },
+      "featureflag.application": {
+        "type": "Project",
+        "dependencies": {
+          "FeatureFlag.Domain": "[1.0.0, )",
+          "FluentValidation": "[12.*, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.5, )"
+        }
+      },
+      "featureflag.domain": {
+        "type": "Project"
+      },
+      "featureflag.infrastructure": {
+        "type": "Project",
+        "dependencies": {
+          "FeatureFlag.Application": "[1.0.0, )",
+          "FeatureFlag.Domain": "[1.0.0, )",
+          "Microsoft.Extensions.Configuration.Abstractions": "[10.0.5, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.5, )",
+          "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.1, )"
+        }
+      }
+    }
+  }
+}

--- a/FeatureFlag.Tests/FeatureFlag.Tests.csproj
+++ b/FeatureFlag.Tests/FeatureFlag.Tests.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
     <PackageReference Include="FluentAssertions" Version="8.9.0" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="10.4.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />

--- a/FeatureFlag.Tests/Services/FeatureFlagServiceLoggingTests.cs
+++ b/FeatureFlag.Tests/Services/FeatureFlagServiceLoggingTests.cs
@@ -1,0 +1,149 @@
+using FeatureFlag.Application.Evaluation;
+using FeatureFlag.Application.Services;
+using FeatureFlag.Application.Strategies;
+using FeatureFlag.Domain.Entities;
+using FeatureFlag.Domain.Enums;
+using FeatureFlag.Domain.Exceptions;
+using FeatureFlag.Domain.Interfaces;
+using FeatureFlag.Domain.ValueObjects;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Testing;
+
+namespace FeatureFlag.Tests.Services;
+
+[Trait("Category", "Unit")]
+public sealed class FeatureFlagServiceLoggingTests
+{
+    private readonly TestFeatureFlagRepository _repo;
+    private readonly FeatureEvaluator _evaluator;
+    private readonly FakeLogger<FeatureFlagService> _fakeLogger;
+    private readonly FeatureFlagService _service;
+
+    public FeatureFlagServiceLoggingTests()
+    {
+        _repo = new TestFeatureFlagRepository();
+        _evaluator = new FeatureEvaluator(new IRolloutStrategy[] { new NoneStrategy() });
+        _fakeLogger = new FakeLogger<FeatureFlagService>();
+        _service = new FeatureFlagService(_repo, _evaluator, _fakeLogger);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task IsEnabledAsync_DisabledFlag_LogsFlagDisabledReasonAsync()
+    {
+        _repo.FlagToReturn = new Flag(
+            "my-flag",
+            EnvironmentType.Development,
+            isEnabled: false,
+            RolloutStrategy.None,
+            null
+        );
+
+        FeatureEvaluationContext context = new("user-1", [], EnvironmentType.Development);
+
+        bool isEnabled = await _service.IsEnabledAsync("my-flag", context);
+
+        FakeLogRecord record = _fakeLogger.LatestRecord;
+
+        Assert.False(isEnabled);
+        Assert.Equal(LogLevel.Information, record.Level);
+        Assert.Equal("FlagDisabled", record.GetStructuredStateValue("Reason")?.ToString());
+        Assert.Null(record.GetStructuredStateValue("StrategyType"));
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task IsEnabledAsync_EnabledFlag_LogsStrategyEvaluatedReasonAsync()
+    {
+        _repo.FlagToReturn = new Flag(
+            "my-flag",
+            EnvironmentType.Development,
+            isEnabled: true,
+            RolloutStrategy.None,
+            null
+        );
+
+        FeatureEvaluationContext context = new("user-1", [], EnvironmentType.Development);
+
+        bool isEnabled = await _service.IsEnabledAsync("my-flag", context);
+
+        FakeLogRecord record = _fakeLogger.LatestRecord;
+
+        Assert.True(isEnabled);
+        Assert.Equal(LogLevel.Information, record.Level);
+        Assert.Equal("StrategyEvaluated", record.GetStructuredStateValue("Reason")?.ToString());
+        Assert.Equal("None", record.GetStructuredStateValue("StrategyType")?.ToString());
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task IsEnabledAsync_AnyOutcome_LogsHashedUserIdNotRawAsync()
+    {
+        _repo.FlagToReturn = new Flag(
+            "my-flag",
+            EnvironmentType.Development,
+            isEnabled: false,
+            RolloutStrategy.None,
+            null
+        );
+
+        const string RawUserId = "user-abc-123";
+        FeatureEvaluationContext context = new(RawUserId, [], EnvironmentType.Development);
+
+        await _service.IsEnabledAsync("my-flag", context);
+
+        FakeLogRecord record = _fakeLogger.LatestRecord;
+        string? loggedUserId = record.GetStructuredStateValue("UserId")?.ToString();
+
+        Assert.NotNull(loggedUserId);
+        Assert.DoesNotContain(RawUserId, record.Message);
+        Assert.NotEqual(RawUserId, loggedUserId);
+        Assert.Matches("^[0-9a-f]{8}$", loggedUserId);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task IsEnabledAsync_FlagNotFound_LogsWarningBeforeExceptionAsync()
+    {
+        _repo.FlagToReturn = null;
+
+        FeatureEvaluationContext context = new("user-1", [], EnvironmentType.Development);
+
+        await Assert.ThrowsAsync<FlagNotFoundException>(() =>
+            _service.IsEnabledAsync("missing-flag", context)
+        );
+
+        FakeLogRecord record = _fakeLogger.LatestRecord;
+
+        Assert.Equal(LogLevel.Warning, record.Level);
+        Assert.Contains("missing-flag", record.Message);
+    }
+
+    private sealed class TestFeatureFlagRepository : IFeatureFlagRepository
+    {
+        public Flag? FlagToReturn { get; set; }
+
+        public Task<Flag?> GetByNameAsync(
+            string name,
+            EnvironmentType environment,
+            CancellationToken ct = default
+        ) => Task.FromResult(FlagToReturn);
+
+        public Task<bool> ExistsAsync(
+            string name,
+            EnvironmentType environment,
+            CancellationToken ct = default
+        ) => throw new NotSupportedException();
+
+        public Task<IReadOnlyList<Flag>> GetAllAsync(
+            EnvironmentType environment,
+            CancellationToken ct = default
+        ) => throw new NotSupportedException();
+
+        public Task AddAsync(Flag flag, CancellationToken ct = default) =>
+            throw new NotSupportedException();
+
+        public Task SaveChangesAsync(CancellationToken ct = default) =>
+            throw new NotSupportedException();
+    }
+}

--- a/FeatureFlag.Tests/packages.lock.json
+++ b/FeatureFlag.Tests/packages.lock.json
@@ -1,0 +1,245 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net10.0": {
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[6.0.4, )",
+        "resolved": "6.0.4",
+        "contentHash": "lkhqpF8Pu2Y7IiN7OntbsTtdbpR1syMsm2F3IgX6ootA4ffRqWL5jF7XipHuZQTdVuWG/gVAAcf8mjk8Tz0xPg=="
+      },
+      "FluentAssertions": {
+        "type": "Direct",
+        "requested": "[8.9.0, )",
+        "resolved": "8.9.0",
+        "contentHash": "Y5RDjxaVlxWX2yy0X/ay1tJjSKMOtjepSb83mmfngFS63hm3LsoZNj6nhmImzm1ifRmpF9ouvmHjx9nNwnkpDg=="
+      },
+      "Microsoft.Extensions.Diagnostics.Testing": {
+        "type": "Direct",
+        "requested": "[10.4.0, )",
+        "resolved": "10.4.0",
+        "contentHash": "V120+GJP1vxV3Gro1oIWP8xmTlejjDlG0BjwPXSbFSv0mRy+dTvCBguRabQD9CNloJ3UvOkmkqsQjyewOg03Gg==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging": "10.0.4",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.4",
+          "Microsoft.Extensions.Telemetry.Abstractions": "10.4.0"
+        }
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[17.14.1, )",
+        "resolved": "17.14.1",
+        "contentHash": "HJKqKOE+vshXra2aEHpi2TlxYX7Z9VFYkr+E5rwEvHC8eIXiyO+K9kNm8vmNom3e2rA56WqxU+/N9NJlLGXsJQ==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "17.14.1",
+          "Microsoft.TestPlatform.TestHost": "17.14.1"
+        }
+      },
+      "xunit": {
+        "type": "Direct",
+        "requested": "[2.9.3, )",
+        "resolved": "2.9.3",
+        "contentHash": "TlXQBinK35LpOPKHAqbLY4xlEen9TBafjs0V5KnA4wZsoQLQJiirCR4CbIXvOH8NzkW4YeJKP5P/Bnrodm0h9Q==",
+        "dependencies": {
+          "xunit.analyzers": "1.18.0",
+          "xunit.assert": "2.9.3",
+          "xunit.core": "[2.9.3]"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[3.1.4, )",
+        "resolved": "3.1.4",
+        "contentHash": "5mj99LvCqrq3CNi06xYdyIAXOEh+5b33F2nErCzI5zWiDdLHXiPXEWFSUAF8zlIv0ZWqjZNCwHTQeAPYbF3pCg=="
+      },
+      "FluentValidation": {
+        "type": "Transitive",
+        "resolved": "12.1.1",
+        "contentHash": "EPpkIe1yh1a0OXyC100oOA8WMbZvqUu5plwhvYcb7oSELfyUZzfxV48BLhvs3kKo4NwG7MGLNgy1RJiYtT8Dpw=="
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "17.14.1",
+        "contentHash": "pmTrhfFIoplzFVbhVwUquT+77CbGH+h4/3mBpdmIlYtBi9nAB+kKI6dN3A/nV4DFi3wLLx/BlHIPK+MkbQ6Tpg=="
+      },
+      "Microsoft.Extensions.Compliance.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.4.0",
+        "contentHash": "4WkknDbVrHNf+S6fwSt1OAXlGJ/G/QrtJlqx4aNzOLmeT3GRyxpGLZn+Q3UV+RMRAF6FfsijEZBg2ZAW8bTAkg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.4",
+          "Microsoft.Extensions.ObjectPool": "10.0.4"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "601B3ha6XvOsOcu9GVd2dVd1KEDuqr49r46GUWhNJkeZDhZ/NI9EYTyoeQjZQEi8ZUvnrv++FbTfGmC8F0vgtg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.4",
+          "Microsoft.Extensions.Primitives": "10.0.4"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "3x9X9SMAMdAoEwWxHfsT2a9dTBqEtfYfbEOFw+UPtBshEH2gHWJeazxrZ1FK1O18MoCbe1NxINg5qciB01pEcg==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.4"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "ilnL/kQn62Gx3OZCVT7SJrBNi0CRIhS8VEunmE6i/a9lp9l/eos+hpxMvCW4iX2aVc/NWeDhxuQusZL7zvmKIg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.4",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.4"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "NkvJ8aSr3AG30yabjv7ZWwTG/wq5OElNTlNq39Ok2HSEF3TIwAc1f1xnTJlR/GuoJmEgkfT7WBO9YbSXRk41+g==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.4"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.5",
+        "contentHash": "iVMtq9eRvzyhx8949EGT0OCYJfXi737SbRVzWXE5GrOgGj5AaZ9eUuxA/BSUfmOMALKn/g8KfFaNQw0eiB3lyA=="
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "S8+6fCuMOhJZGk8sGFtOy3VsF9mk9x4UOL59GM91REiA/fmCDjunKKIw4RmStG87qyXPfxelDJf2pXIbTuaBdw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "10.0.4",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.4",
+          "Microsoft.Extensions.Options": "10.0.4"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "PDMMt7fvBatv6hcxxyJtXIzSwn7Dy00W6I2vDAOTYrQqNM2dF5A2L9n0uMzdPz2IPoNZWkAmYjoOCEdDLq0i4w==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.4"
+        }
+      },
+      "Microsoft.Extensions.ObjectPool": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "2pufIFOgNl/yWTOoIC9XgBnO9VxgfAjdRCnVwpE2+ICfcroGnjuEAGzJ5lTdZeAe0HvA31vMBWXtcmGB7TOq3g=="
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "kRxa2Zjzhg/ohh7EklpqQpBIcyQnC3meWxCcpZBn+0QWy/fY1DmDd45JiW8Vyrpj2J1RDtau5yRHiLZS/AoxUw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.4",
+          "Microsoft.Extensions.Primitives": "10.0.4"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "amQUITwSnkbMPxh/ngneNykz4UtytEOXo0M/pbwdBiQU57EAVvBV5PFI8r/dRastUj0yxHVwrH64N9ACR5SdGQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.4",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.4",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.4",
+          "Microsoft.Extensions.Options": "10.0.4",
+          "Microsoft.Extensions.Primitives": "10.0.4"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.4",
+        "contentHash": "lABYqiRH9HgYJsjzO3W7+cucUwWXhEkiyrRylANdIubnzcESlkIsLowXpQ4E+sc7kjMLbk1hk5oxw4qTKowTEg=="
+      },
+      "Microsoft.Extensions.Telemetry.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.4.0",
+        "contentHash": "3b2uVa4voJfLLg39BPCKQS0ZgnpEZFkKf7YmnMVlM5FQJYBPOuePIQdnEK1/Oxd+w3GscxGYuE7IMOXDwixZtQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Compliance.Abstractions": "10.4.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.4",
+          "Microsoft.Extensions.ObjectPool": "10.0.4",
+          "Microsoft.Extensions.Options": "10.0.4"
+        }
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "17.14.1",
+        "contentHash": "xTP1W6Mi6SWmuxd3a+jj9G9UoC850WGwZUps1Wah9r1ZxgXhdJfj1QqDLJkFjHDCvN42qDL2Ps5KjQYWUU0zcQ=="
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "17.14.1",
+        "contentHash": "d78LPzGKkJwsJXAQwsbJJ7LE7D1wB+rAyhHHAaODF+RDSQ0NgMjDFkSA1Djw18VrxO76GlKAjRUhl+H8NL8Z+Q==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "17.14.1",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "xunit.abstractions": {
+        "type": "Transitive",
+        "resolved": "2.0.3",
+        "contentHash": "pot1I4YOxlWjIb5jmwvvQNbTrZ3lJQ+jUGkGjWE3hEFM0l5gOnBWS+H3qsex68s5cO52g+44vpGzhAt+42vwKg=="
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.18.0",
+        "contentHash": "OtFMHN8yqIcYP9wcVIgJrq01AfTxijjAqVDy/WeQVSyrDC1RzBWeQPztL49DN2syXRah8TYnfvk035s7L95EZQ=="
+      },
+      "xunit.assert": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "/Kq28fCE7MjOV42YLVRAJzRF0WmEqsmflm0cfpMjGtzQ2lR5mYVj1/i0Y8uDAOLczkL3/jArrwehfMD0YogMAA=="
+      },
+      "xunit.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "BiAEvqGvyme19wE0wTKdADH+NloYqikiU0mcnmiNyXaF9HyHmE6sr/3DC5vnBkgsWaE6yPyWszKSPSApWdRVeQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]",
+          "xunit.extensibility.execution": "[2.9.3]"
+        }
+      },
+      "xunit.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "kf3si0YTn2a8J8eZNb+zFpwfoyvIrQ7ivNk5ZYA5yuYk1bEtMe4DxJ2CF/qsRgmEnDr7MnW1mxylBaHTZ4qErA==",
+        "dependencies": {
+          "xunit.abstractions": "2.0.3"
+        }
+      },
+      "xunit.extensibility.execution": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "yMb6vMESlSrE3Wfj7V6cjQ3S4TXdXpRqYeNEI3zsX31uTsGMJjEw6oD5F5u1cHnMptjhEECnmZSsPxB6ChZHDQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]"
+        }
+      },
+      "featureflag.application": {
+        "type": "Project",
+        "dependencies": {
+          "FeatureFlag.Domain": "[1.0.0, )",
+          "FluentValidation": "[12.*, )",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.5, )"
+        }
+      },
+      "featureflag.domain": {
+        "type": "Project"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add typed evaluation result models and structured logging in `FeatureFlagService`, including machine-readable reasons, hashed user identifiers, and not-found warnings
- add focused service logging tests plus implementation notes and the finalized decision spec for evaluation logging
- enable NuGet lock file restore support and commit the generated project lock files included in this branch

## Test plan
- [x] `dotnet csharpier format .`
- [x] `dotnet build FeatureFlagService.sln`
- [x] `dotnet test FeatureFlagService.sln --filter "Category=Unit"`
- [x] `dotnet test FeatureFlagService.sln --filter "Category=Integration"`
- [x] `dotnet csharpier check .`