### PR TITLE
feat: add development seed data startup flow

### DIFF
--- a/Docs/Decisions/seed-data - PR###/implementation-notes.md
+++ b/Docs/Decisions/seed-data - PR###/implementation-notes.md
@@ -1,0 +1,47 @@
+# Seed Data for Local Development — Implementation Notes
+
+**Session date:** 2026-04-13
+**Branch:** `feature/phase1-finish-line`
+**Spec reference:** `Docs/Decisions/seed-data - PR###/spec-v3.md`
+**Build status:** Passed — 0 warnings, 0 errors
+**Tests:** 113/113 passing (81 unit + 32 integration)
+**PR:** `PR###` — update after PR creation
+
+---
+
+## Deviations from Spec
+
+### DEV-001 — `DatabaseSeeder` Must Be `public` for Api Startup Resolution
+
+**Spec says:** `DatabaseSeeder` is `internal sealed`.
+
+**What actually happened:** `Program.cs` in `FeatureFlag.Api` resolves `DatabaseSeeder`
+from DI and calls `SeedAsync(...)` directly during startup. `FeatureFlag.Api` and
+`FeatureFlag.Infrastructure` are separate assemblies, so an `internal` seeder type
+and its members are not visible at the call site. The build fails with `CS0122`
+if `DatabaseSeeder` remains `internal`.
+
+**Fix applied:** Changed `DatabaseSeeder` to `public sealed`.
+
+**Why this is acceptable:** This is an assembly visibility requirement, not an
+architectural broadening of responsibility. The seeder is still registered only in
+Infrastructure, used only from startup wiring, and not exposed on any API surface.
+
+---
+
+## Build Verification
+
+- `dotnet ef migrations add AddIsSeededToFlag --project "FeatureFlag.Infrastructure" --startup-project "FeatureFlag.Api"` -> passed
+- `dotnet ef database update --project "FeatureFlag.Infrastructure" --startup-project "FeatureFlag.Api" --connection "Host=postgres;Port=5432;Database=featureflags;Username=postgres;Password=postgres"` -> passed
+- `dotnet csharpier check .` -> passed
+- `dotnet build FeatureFlagService.sln -p:TreatWarningsAsErrors=true` -> 0 warnings, 0 errors
+- `dotnet test FeatureFlagService.sln` -> 113/113 passing
+
+---
+
+## Notes
+
+- The `AddIsSeededToFlag` migration was generated and applied against the running
+  Postgres devcontainer, not an in-memory provider.
+- The implementation follows `spec-v3.md` aside from the `public` visibility change
+  documented above.

--- a/Docs/Decisions/seed-data - PR###/spec-v2.md
+++ b/Docs/Decisions/seed-data - PR###/spec-v2.md
@@ -1,0 +1,478 @@
+# Specification: Seed Data for Local Development (v2)
+
+**Document:** `Docs/Decisions/seed-data/spec-v2.md`
+**Branch:** `feature/phase1-finish-line`
+**Phase:** 1 — Developer Experience
+**Status:** Ready for Implementation
+**Replaces:** v1 — revised after AI reviewer findings
+**Author:** Jose / Claude Architect Session
+**Date:** 2026-04-13
+
+---
+
+## Revision Log — v1 → v2
+
+| Finding | v1 | v2 Fix |
+|---------|-----|--------|
+| No provenance marker | Reset targeted by Name + Environment — ambiguous | Added `IsSeeded` bool column; reset targets `IsSeeded = true` only |
+| DD-2 and AC-2 contradicted each other | DD-2: skip all if any exist / AC-2: per-record backfill | Resolved to per-record backfill; self-healing behavior |
+| Archived seed flags blocked re-insertion | Archived flags counted as "existing" — demo baseline never restored | Existence check targets non-archived rows only; archived seed flags are backfilled |
+| `StrategyConfig = null` conflicts with domain | Domain normalizes `null` → `"{}"` | Manifest passes `"{}"` explicitly for all None strategy flags |
+| Migration prerequisite unspecified | `MigrateAsync()` mentioned only as "if it exists" | `MigrateAsync()` added explicitly to Development startup block, before seeder |
+| Reset could delete manually created flags | Delete by Name + Environment — no provenance distinction | Reset deletes only where `IsSeeded = true` — manual flags untouched |
+
+---
+
+## Table of Contents
+
+- [User Story](#user-story)
+- [Background & Goals](#background--goals)
+- [Design Decisions](#design-decisions)
+  - [DD-1: Automatic Startup Seeding, Development Only](#dd-1-automatic-startup-seeding-development-only)
+  - [DD-2: Provenance Marker — IsSeeded](#dd-2-provenance-marker--isseeded)
+  - [DD-3: Idempotency — Per-Record Backfill](#dd-3-idempotency--per-record-backfill)
+  - [DD-4: Reset Mode — Target IsSeeded Only](#dd-4-reset-mode--target-isseeded-only)
+  - [DD-5: Migration on Startup](#dd-5-migration-on-startup)
+  - [DD-6: Layer Placement](#dd-6-layer-placement)
+- [Scope](#scope)
+- [Seed Records](#seed-records)
+- [Acceptance Criteria](#acceptance-criteria)
+  - [AC-1: IsSeeded Column and Migration](#ac-1-isseeded-column-and-migration)
+  - [AC-2: DatabaseSeeder Class](#ac-2-databaseseeder-class)
+  - [AC-3: Normal Mode — Per-Record Backfill](#ac-3-normal-mode--per-record-backfill)
+  - [AC-4: Reset Mode — Wipe Seeded Rows and Re-insert](#ac-4-reset-mode--wipe-seeded-rows-and-re-insert)
+  - [AC-5: Startup Wiring in Program.cs](#ac-5-startup-wiring-in-programcs)
+  - [AC-6: DI Registration](#ac-6-di-registration)
+  - [AC-7: Seed Record Coverage](#ac-7-seed-record-coverage)
+  - [AC-8: Logging](#ac-8-logging)
+- [File Layout](#file-layout)
+- [Implementation Notes](#implementation-notes)
+- [Out of Scope](#out-of-scope)
+- [Definition of Done](#definition-of-done)
+
+---
+
+## User Story
+
+> As a developer (or recruiter evaluating this project), I want a working set of
+> feature flags automatically available when I run `docker compose up` — so I can
+> explore and test the API immediately without any manual database setup.
+
+---
+
+## Background & Goals
+
+Currently, a developer who clones the repo and starts the app has an empty database.
+Every manual test requires creating flags by hand before anything meaningful can be
+evaluated. This creates two problems:
+
+1. **Onboarding friction** — new developers and recruiters cannot immediately explore
+   the API. The "15-minute demo" promise in the product vision is broken.
+
+2. **Dev data rot** — developers who have been working for days or weeks accumulate
+   test data that no longer reflects a known clean state. There is no way to reset
+   to a baseline without manually deleting rows.
+
+This spec introduces a `DatabaseSeeder` that solves both problems. It seeds a curated
+set of representative flags on startup (Development only) and supports a controlled
+reset that targets only seeder-owned rows — leaving developer-created flags untouched.
+
+---
+
+## Design Decisions
+
+### DD-1: Automatic Startup Seeding, Development Only
+
+The seeder runs automatically during application startup. No manual CLI step is
+required. This preserves the `docker compose up` onboarding experience described
+in the product vision.
+
+The seeder is guarded by `IHostEnvironment.IsDevelopment()` at the `Program.cs`
+call site. It will not execute in Staging or Production under any circumstances.
+The seeder itself has no knowledge of the environment — the guard is the caller's
+responsibility.
+
+**Rejected: EF Core `HasData()`** — baked into migrations, runs in all environments,
+cannot support conditional or reset behavior without significant workarounds.
+
+**Rejected: CLI command only** — requires a manual step after startup, breaking the
+`docker compose up` onboarding flow.
+
+**Rejected: Full database wipe on startup** — destroys developer-created flags on
+container restart. Unacceptable data loss for active development.
+
+---
+
+### DD-2: Provenance Marker — IsSeeded
+
+A new `bool` column `IsSeeded` is added to the `Flag` entity and persisted via
+a new EF Core migration. The seeder stamps every record it creates with
+`IsSeeded = true`. All existing rows and all manually created flags default to
+`IsSeeded = false`.
+
+This gives the seeder a reliable, unambiguous way to identify the rows it owns —
+without relying on name matching, which cannot distinguish a seeded flag from a
+developer flag that happens to share the same name.
+
+**Migration default:** `false`. Existing rows are unaffected.
+
+---
+
+### DD-3: Idempotency — Per-Record Backfill
+
+On every startup (normal mode), the seeder checks each seed record individually.
+Records that already exist as active (non-archived) rows are skipped. Records that
+are missing — because they were archived, deleted, or never inserted — are
+re-inserted.
+
+This is a **self-healing** behavior. If a developer archives a seeded flag, the
+next startup restores it. The demo baseline is always recoverable without a full
+reset.
+
+**Rejected: Skip all seeding if any seed records exist** — fragile. A single
+existing record suppresses all other inserts. Demo baseline degrades silently over
+time.
+
+---
+
+### DD-4: Reset Mode — Target IsSeeded Only
+
+Reset mode is triggered by the environment variable `SEED_RESET=true`. When active:
+
+1. All rows where `IsSeeded = true` are deleted via `ExecuteDeleteAsync`
+2. The full seed manifest is re-inserted unconditionally
+
+Reset is scoped entirely to `IsSeeded = true` rows. Flags created manually by
+developers are never deleted — regardless of whether their name matches a seed
+record.
+
+The variable is passed without modifying source code:
+
+```bash
+SEED_RESET=true docker compose up
+```
+
+---
+
+### DD-5: Migration on Startup
+
+The app does not currently migrate automatically. On a fresh `docker compose up`,
+the database has no schema — the seeder would crash before it could insert anything.
+
+`app.MigrateAsync()` is added to the Development startup block, immediately before
+the seeder call. Schema is guaranteed to exist before seeding is attempted.
+
+This guard is Development-only for the same reason as the seeder: in Production,
+migrations are a controlled deployment step reviewed before the app starts — not
+an automatic side effect of startup.
+
+---
+
+### DD-6: Layer Placement
+
+| Concern | Layer | Location |
+|---------|-------|----------|
+| `Flag.IsSeeded` property | Domain | `Domain/Entities/Flag.cs` |
+| EF Core column mapping | Infrastructure | `Infrastructure/Persistence/Configurations/FlagConfiguration.cs` |
+| Migration | Infrastructure | `Infrastructure/Persistence/Migrations/` |
+| `DatabaseSeeder` class | Infrastructure | `Infrastructure/Seeding/DatabaseSeeder.cs` |
+| DI registration | Infrastructure | `Infrastructure/DependencyInjection.cs` |
+| Startup trigger + guard | Api | `FeatureFlag.Api/Program.cs` |
+
+---
+
+## Scope
+
+| # | What | File(s) Affected |
+|---|------|-----------------|
+| 1 | `IsSeeded` property on `Flag` entity | `Domain/Entities/Flag.cs` |
+| 2 | EF Core column mapping for `IsSeeded` | `Infrastructure/Persistence/Configurations/FlagConfiguration.cs` |
+| 3 | New migration | `Infrastructure/Persistence/Migrations/` |
+| 4 | `DatabaseSeeder` class | `Infrastructure/Seeding/DatabaseSeeder.cs` |
+| 5 | DI registration | `Infrastructure/DependencyInjection.cs` |
+| 6 | Startup wiring + migration call | `FeatureFlag.Api/Program.cs` |
+
+No new endpoints. No changes to validators, DTOs, or existing repository methods.
+
+---
+
+## Seed Records
+
+The seeder inserts the following six flags. They are designed to exercise all three
+rollout strategies across two environments — giving a developer or recruiter an
+immediately meaningful API to explore.
+
+| Name | Environment | Strategy | Enabled | StrategyConfig |
+|------|-------------|----------|---------|----------------|
+| `dark-mode` | Development | None | `true` | `"{}"` |
+| `new-dashboard` | Development | Percentage | `true` | `{"percentage":30}` |
+| `beta-features` | Development | RoleBased | `true` | `{"roles":["Admin","Beta"]}` |
+| `maintenance-mode` | Development | None | `false` | `"{}"` |
+| `dark-mode` | Staging | None | `true` | `"{}"` |
+| `new-dashboard` | Staging | Percentage | `true` | `{"percentage":50}` |
+
+All records are stamped with `IsSeeded = true` at insert time.
+
+`StrategyConfig` is `"{}"` for all `None` strategy flags — this matches the value
+the domain stores after normalization (`null` input → `"{}"` stored). The manifest
+passes `"{}"` explicitly to avoid relying on that normalization as a side effect.
+
+---
+
+## Acceptance Criteria
+
+---
+
+### AC-1: IsSeeded Column and Migration
+
+**Files:**
+- `FeatureFlag.Domain/Entities/Flag.cs`
+- `FeatureFlag.Infrastructure/Persistence/Configurations/FlagConfiguration.cs`
+- `FeatureFlag.Infrastructure/Persistence/Migrations/<timestamp>_AddIsSeededToFlag.cs`
+
+**Domain:**
+- Add `public bool IsSeeded { get; private set; }` to the `Flag` entity
+- Default value: `false`
+- No changes to any existing constructor or mutation method signatures
+- `IsSeeded` is not exposed on any DTO or API response — it is an internal
+  infrastructure concern only
+
+**EF Core mapping:**
+```csharp
+builder.Property(f => f.IsSeeded)
+    .IsRequired()
+    .HasDefaultValue(false);
+```
+
+**Migration:**
+- Generated via `dotnet ef migrations add AddIsSeededToFlag`
+- Existing rows receive `IsSeeded = false` via the column default
+- Migration must apply cleanly against the current schema with no data loss
+
+---
+
+### AC-2: DatabaseSeeder Class
+
+**File:** `FeatureFlag.Infrastructure/Seeding/DatabaseSeeder.cs`
+
+- Class is `internal sealed`
+- Constructor accepts `AppDbContext` and `ILogger<DatabaseSeeder>`
+- Exposes a single public method: `Task SeedAsync(bool reset, CancellationToken ct = default)`
+- Does not reference any Application layer types — uses `AppDbContext` directly
+- Does not reference `IFeatureFlagRepository`
+
+```csharp
+internal sealed class DatabaseSeeder(
+    AppDbContext db,
+    ILogger<DatabaseSeeder> logger)
+{
+    public async Task SeedAsync(bool reset, CancellationToken ct = default)
+    { ... }
+}
+```
+
+---
+
+### AC-3: Normal Mode — Per-Record Backfill
+
+When `reset` is `false`:
+
+- Iterate over each record in the seed manifest
+- For each record, check whether an active (non-archived) flag with that `Name`
+  and `Environment` already exists using `AnyAsync` on `AppDbContext.Flags`
+- Existence check filters: `Name == record.Name && Environment == record.Environment && !IsArchived`
+- If active record exists → skip, log at `Debug`:
+  `"Seed record '{Name}' ({Environment}) already exists — skipping."`
+- If no active record exists → construct a `Flag` entity via the domain constructor,
+  set `IsSeeded = true`, add to context, save
+- After processing all records, if any were inserted → log at `Information`:
+  `"Seeded {Count} flag(s)."`
+- If all records were skipped → log at `Information`:
+  `"Seeding skipped — all seed records already present."`
+
+**Archived seed flags are treated as missing** — if a seeded flag was archived,
+the existence check returns false and the record is re-inserted on next startup.
+This is intentional: the seeder maintains the demo baseline automatically.
+
+---
+
+### AC-4: Reset Mode — Wipe Seeded Rows and Re-insert
+
+When `reset` is `true`:
+
+- Log at `Warning` before delete:
+  `"SEED_RESET=true — deleting all seeded records before re-seeding."`
+- Delete all rows where `IsSeeded = true` using `ExecuteDeleteAsync`:
+```csharp
+await db.Flags.Where(f => f.IsSeeded).ExecuteDeleteAsync(ct);
+```
+- Re-insert all seed manifest records unconditionally, each stamped with
+  `IsSeeded = true`
+- Log at `Information` after insert:
+  `"Re-seeded {Count} flag(s)."`
+
+**Reset is scoped to `IsSeeded = true` rows only.** Flags where `IsSeeded = false`
+are never touched — regardless of whether their name matches a seed record.
+
+---
+
+### AC-5: Startup Wiring in Program.cs
+
+**File:** `FeatureFlag.Api/Program.cs`
+
+The following block is added after `app.MapControllers()`:
+
+```csharp
+if (app.Environment.IsDevelopment())
+{
+    await app.MigrateAsync();
+
+    using var scope = app.Services.CreateScope();
+    var seeder = scope.ServiceProvider.GetRequiredService<DatabaseSeeder>();
+    var reset = Environment.GetEnvironmentVariable("SEED_RESET") == "true";
+    await seeder.SeedAsync(reset);
+}
+```
+
+- `MigrateAsync()` runs first — schema is guaranteed before seeding
+- `SEED_RESET` is read via `Environment.GetEnvironmentVariable()`, not
+  `IConfiguration` — keeps the reset signal separate from application config
+- The seeder is resolved from a scoped `IServiceProvider` — required because
+  `DatabaseSeeder` depends on the scoped `AppDbContext`
+- If `app.MigrateAsync()` does not exist as an extension method, implement it
+  as a local extension in `FeatureFlag.Api/Extensions/WebApplicationExtensions.cs`:
+
+```csharp
+public static async Task MigrateAsync(this WebApplication app)
+{
+    using var scope = app.Services.CreateScope();
+    var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+    await db.Database.MigrateAsync();
+}
+```
+
+---
+
+### AC-6: DI Registration
+
+**File:** `FeatureFlag.Infrastructure/DependencyInjection.cs`
+
+Add to the `AddInfrastructure()` extension method:
+
+```csharp
+services.AddScoped<DatabaseSeeder>();
+```
+
+---
+
+### AC-7: Seed Record Coverage
+
+The seeder inserts exactly the six records defined in the [Seed Records](#seed-records)
+table. Each record is constructed using the `Flag` domain constructor — not via
+object initializers that bypass domain invariants or raw SQL.
+
+After construction, `IsSeeded` is set to `true` before the entity is added to the
+context. Because `IsSeeded` has a private setter, the seeder must set it via one
+of the following approaches (Claude Code should determine which is cleanest given
+the current domain shape):
+
+- A constructor overload that accepts `isSeeded`
+- An `internal` method `MarkAsSeeded()` on the `Flag` entity
+- An `internal` setter promoted from `private` — accessible within Infrastructure
+  because both projects are in the same solution
+
+The chosen approach must not expose `IsSeeded` mutation on the public API surface.
+
+---
+
+### AC-8: Logging
+
+All log messages use structured logging with named properties — no string
+interpolation.
+
+| Scenario | Level | Message Template |
+|----------|-------|-----------------|
+| Active record exists (per record) | Debug | `"Seed record '{Name}' ({Environment}) already exists — skipping."` |
+| All records already present | Information | `"Seeding skipped — all seed records already present."` |
+| Records inserted (normal mode) | Information | `"Seeded {Count} flag(s)."` |
+| Reset triggered | Warning | `"SEED_RESET=true — deleting all seeded records before re-seeding."` |
+| Reset complete | Information | `"Re-seeded {Count} flag(s)."` |
+
+No user-identifying data is logged. Seed records contain no PII.
+
+---
+
+## File Layout
+
+```
+FeatureFlag.Domain/
+  Entities/
+    Flag.cs                                         ← modified (IsSeeded property)
+
+FeatureFlag.Infrastructure/
+  Persistence/
+    Configurations/
+      FlagConfiguration.cs                          ← modified (IsSeeded mapping)
+    Migrations/
+      <timestamp>_AddIsSeededToFlag.cs              ← new migration
+  Seeding/
+    DatabaseSeeder.cs                               ← new
+
+FeatureFlag.Api/
+  Extensions/
+    WebApplicationExtensions.cs                     ← new (MigrateAsync helper)
+  Program.cs                                        ← modified (Development block)
+
+FeatureFlag.Infrastructure/
+  DependencyInjection.cs                            ← modified (register DatabaseSeeder)
+```
+
+---
+
+## Implementation Notes
+
+- `ExecuteDeleteAsync` requires EF Core 7+. Already available (EF Core 10).
+- `IsSeeded` must not appear on `FlagResponse` or any other DTO — it is an
+  internal infrastructure concern only. API consumers have no knowledge of it.
+- The seeder calls `AppDbContext` directly — do not route through
+  `IFeatureFlagRepository`. The repository is the Application layer's boundary;
+  the seeder lives in Infrastructure and may use `DbContext` directly.
+- The manifest literals (`"dark-mode"`, `"Admin"`, etc.) are trusted constant
+  data defined by the engineer — `InputSanitizer` is not required for seed
+  manifest values. This is an explicit exception to the sanitization rule, which
+  applies to untrusted HTTP input surfaces only.
+- CSharpier formatting must pass — run `dotnet csharpier .` before committing.
+- The migration must be generated against the running Postgres devcontainer, not
+  an in-memory provider. Use the devcontainer terminal.
+
+---
+
+## Out of Scope
+
+- Seed data for Staging or Production environments
+- A dedicated reset CLI command or API endpoint
+- Changes to existing validators, DTOs, or repository methods
+- Seed data for integration tests — test data is owned by each test class
+  via Testcontainers setup
+- Exposing `IsSeeded` on any API response
+
+---
+
+## Definition of Done
+
+- [ ] `IsSeeded` property exists on `Flag` entity with `private` setter
+- [ ] EF Core column mapping added to `FlagConfiguration.cs`
+- [ ] Migration generated and applies cleanly with no data loss
+- [ ] `DatabaseSeeder` exists at `Infrastructure/Seeding/DatabaseSeeder.cs`
+- [ ] `DatabaseSeeder` registered as scoped in `AddInfrastructure()`
+- [ ] `MigrateAsync()` extension exists and is called first in the Development block
+- [ ] Seeder is called in `Program.cs` inside an `IsDevelopment()` guard
+- [ ] Normal mode is per-record — backfills missing or archived seed records
+- [ ] Reset mode deletes only `IsSeeded = true` rows — manual flags untouched
+- [ ] All six seed records inserted covering all three strategies and two environments
+- [ ] `IsSeeded = true` stamped on every seeder-inserted row
+- [ ] `IsSeeded` not present on any DTO or API response
+- [ ] All log messages use structured logging with named properties
+- [ ] `dotnet build` passes with 0 warnings, 0 errors
+- [ ] All 110 existing tests still pass
+- [ ] CSharpier check passes

--- a/Docs/Decisions/seed-data - PR###/spec-v3.md
+++ b/Docs/Decisions/seed-data - PR###/spec-v3.md
@@ -1,0 +1,589 @@
+# Specification: Seed Data for Local Development (v3)
+
+**Document:** `Docs/Decisions/seed-data/spec-v3.md`
+**Branch:** `feature/phase1-finish-line`
+**Phase:** 1 — Developer Experience
+**Status:** Ready for Implementation
+**Replaces:** v2 — revised after second AI reviewer pass
+**Author:** Jose / Claude Architect Session
+**Date:** 2026-04-13
+
+---
+
+## Revision Log — v2 → v3
+
+| Finding | v2 | v3 Fix |
+|---------|-----|--------|
+| Reset collision on shared identity | Reset deleted `IsSeeded = true` rows then re-inserted unconditionally — would fail unique index if a manual flag occupied the same slot | Reset skips slots occupied by active non-seeded flags; logs a local override warning instead of failing |
+| Wrong DbContext class name | Spec referenced `AppDbContext` throughout | Corrected to `FeatureFlagDbContext` everywhere |
+| Wrong FlagConfiguration path | Spec referenced `Persistence/Configurations/FlagConfiguration.cs` | Corrected to `FeatureFlag.Infrastructure/Persistence/FlagConfiguration.cs` |
+| `internal` across assembly boundary | AC-7 suggested `internal` setter — invalid across Domain/Infrastructure boundary without `InternalsVisibleTo` | Resolved to constructor overload accepting `isSeeded` — explicit, no assembly coupling |
+
+---
+
+## Table of Contents
+
+- [User Story](#user-story)
+- [Background & Goals](#background--goals)
+- [Design Decisions](#design-decisions)
+  - [DD-1: Automatic Startup Seeding, Development Only](#dd-1-automatic-startup-seeding-development-only)
+  - [DD-2: Provenance Marker — IsSeeded](#dd-2-provenance-marker--isseeded)
+  - [DD-3: Seed Identities Are Reserved Baseline Slots](#dd-3-seed-identities-are-reserved-baseline-slots)
+  - [DD-4: Normal Mode — Per-Record Backfill](#dd-4-normal-mode--per-record-backfill)
+  - [DD-5: Reset Mode — Target IsSeeded Only, Skip Collisions](#dd-5-reset-mode--target-isseeded-only-skip-collisions)
+  - [DD-6: Migration on Startup](#dd-6-migration-on-startup)
+  - [DD-7: IsSeeded Stamping via Constructor Overload](#dd-7-isseeded-stamping-via-constructor-overload)
+  - [DD-8: Layer Placement](#dd-8-layer-placement)
+- [Scope](#scope)
+- [Seed Records](#seed-records)
+- [Acceptance Criteria](#acceptance-criteria)
+  - [AC-1: IsSeeded Column and Migration](#ac-1-isseeded-column-and-migration)
+  - [AC-2: Flag Constructor Overload](#ac-2-flag-constructor-overload)
+  - [AC-3: DatabaseSeeder Class](#ac-3-databaseseeder-class)
+  - [AC-4: Normal Mode — Per-Record Backfill](#ac-4-normal-mode--per-record-backfill)
+  - [AC-5: Reset Mode — Wipe Seeded Rows, Skip Collisions](#ac-5-reset-mode--wipe-seeded-rows-skip-collisions)
+  - [AC-6: Startup Wiring in Program.cs](#ac-6-startup-wiring-in-programcs)
+  - [AC-7: DI Registration](#ac-7-di-registration)
+  - [AC-8: Seed Record Coverage](#ac-8-seed-record-coverage)
+  - [AC-9: Logging](#ac-9-logging)
+- [File Layout](#file-layout)
+- [Implementation Notes](#implementation-notes)
+- [Out of Scope](#out-of-scope)
+- [Definition of Done](#definition-of-done)
+
+---
+
+## User Story
+
+> As a developer (or recruiter evaluating this project), I want a working set of
+> feature flags automatically available when I run `docker compose up` — so I can
+> explore and test the API immediately without any manual database setup.
+
+---
+
+## Background & Goals
+
+Currently, a developer who clones the repo and starts the app has an empty database.
+Every manual test requires creating flags by hand before anything meaningful can be
+evaluated. This creates two problems:
+
+1. **Onboarding friction** — new developers and recruiters cannot immediately explore
+   the API. The "15-minute demo" promise in the product vision is broken.
+
+2. **Dev data rot** — developers who have been working for days or weeks accumulate
+   test data that no longer reflects a known clean state. There is no way to reset
+   to a baseline without manually deleting rows.
+
+This spec introduces a `DatabaseSeeder` that solves both problems. It seeds a curated
+set of representative flags on startup (Development only), supports a controlled reset
+that targets only seeder-owned rows, and never touches flags created manually by
+developers.
+
+---
+
+## Design Decisions
+
+### DD-1: Automatic Startup Seeding, Development Only
+
+The seeder runs automatically during application startup. No manual CLI step is
+required. This preserves the `docker compose up` onboarding experience described
+in the product vision.
+
+The seeder is guarded by `IHostEnvironment.IsDevelopment()` at the `Program.cs`
+call site. It will not execute in Staging or Production under any circumstances.
+The seeder itself has no knowledge of the environment — the guard is the caller's
+responsibility.
+
+**Rejected: EF Core `HasData()`** — baked into migrations, runs in all environments,
+cannot support conditional or reset behavior without significant workarounds.
+
+**Rejected: CLI command only** — requires a manual step after startup, breaking the
+`docker compose up` onboarding flow.
+
+**Rejected: Full database wipe on startup** — destroys developer-created flags on
+container restart. Unacceptable data loss for active development.
+
+---
+
+### DD-2: Provenance Marker — IsSeeded
+
+A new `bool` column `IsSeeded` is added to the `Flag` entity and persisted via
+a new EF Core migration. The seeder stamps every record it creates with
+`IsSeeded = true`. All existing rows and all manually created flags default to
+`IsSeeded = false`.
+
+This gives the seeder a reliable, unambiguous way to identify the rows it owns —
+without relying on name matching, which cannot distinguish a seeded flag from a
+developer flag that happens to share the same name and environment.
+
+**Migration default:** `false`. Existing rows receive `false` automatically.
+
+---
+
+### DD-3: Seed Identities Are Reserved Baseline Slots
+
+Each combination of `Name` + `Environment` in the seed manifest represents a
+**reserved baseline slot** — a known identity that the seeder manages. This is
+a local development convention, not a runtime enforcement.
+
+Developers may create flags in seed slots if they choose. The seeder respects
+their data and will never overwrite or delete it. Instead, the seeder treats any
+active row in a seed slot as "satisfied" — whether or not the row is seeder-owned.
+
+---
+
+### DD-4: Normal Mode — Per-Record Backfill
+
+On every startup (normal mode), the seeder checks each seed record individually.
+Records that already have an active (non-archived) row in their slot — whether
+seeded or manually created — are skipped. Records whose slot is empty (no active
+row exists) are inserted.
+
+This is a **self-healing** behavior. If a developer archives a seeded flag, the
+next startup restores it. The demo baseline is always recoverable without a
+full reset.
+
+**Rejected: Skip all seeding if any seed records exist** — fragile. A single
+existing record suppresses all other inserts. Demo baseline degrades silently.
+
+---
+
+### DD-5: Reset Mode — Target IsSeeded Only, Skip Collisions
+
+Reset mode is triggered by the environment variable `SEED_RESET=true`. When active:
+
+1. All rows where `IsSeeded = true` are deleted via `ExecuteDeleteAsync`
+2. For each manifest record, check whether an active non-seeded row already
+   occupies the slot
+3. If a non-seeded active row occupies the slot → skip insertion, log at `Warning`
+4. If the slot is free → insert the manifest record with `IsSeeded = true`
+
+This preserves the guarantee: **manually created flags are never deleted, regardless
+of reset mode.**
+
+The variable is passed without modifying source code:
+
+```bash
+SEED_RESET=true docker compose up
+```
+
+---
+
+### DD-6: Migration on Startup
+
+The app does not currently migrate automatically. On a fresh `docker compose up`,
+the database has no schema — the seeder would crash before it could insert anything.
+
+`app.MigrateAsync()` is added to the Development startup block, immediately before
+the seeder call. Schema is guaranteed to exist before seeding is attempted.
+
+This guard is Development-only for the same reason as the seeder: in Production,
+migrations are a controlled deployment step reviewed and approved before the app
+starts — not an automatic side effect of startup.
+
+---
+
+### DD-7: IsSeeded Stamping via Constructor Overload
+
+`Domain` and `Infrastructure` are separate assemblies. An `internal` setter on
+`Flag` would not be accessible from `DatabaseSeeder` without `InternalsVisibleTo`,
+which adds unnecessary assembly coupling.
+
+Instead, the `Flag` entity receives a second constructor overload that accepts
+`isSeeded`. The seeder uses this overload. All other callers — controllers,
+service layer, existing tests — continue to use the original constructor, which
+defaults `isSeeded` to `false`.
+
+---
+
+### DD-8: Layer Placement
+
+| Concern | Layer | Location |
+|---------|-------|----------|
+| `Flag.IsSeeded` property + constructor overload | Domain | `Domain/Entities/Flag.cs` |
+| EF Core column mapping | Infrastructure | `Infrastructure/Persistence/FlagConfiguration.cs` |
+| Migration | Infrastructure | `Infrastructure/Persistence/Migrations/` |
+| `DatabaseSeeder` class | Infrastructure | `Infrastructure/Seeding/DatabaseSeeder.cs` |
+| DI registration | Infrastructure | `Infrastructure/DependencyInjection.cs` |
+| `MigrateAsync()` extension | Api | `FeatureFlag.Api/Extensions/WebApplicationExtensions.cs` |
+| Startup trigger + guard | Api | `FeatureFlag.Api/Program.cs` |
+
+---
+
+## Scope
+
+| # | What | File(s) Affected |
+|---|------|-----------------|
+| 1 | `IsSeeded` property + constructor overload on `Flag` | `Domain/Entities/Flag.cs` |
+| 2 | EF Core column mapping for `IsSeeded` | `Infrastructure/Persistence/FlagConfiguration.cs` |
+| 3 | New EF Core migration | `Infrastructure/Persistence/Migrations/` |
+| 4 | `DatabaseSeeder` class | `Infrastructure/Seeding/DatabaseSeeder.cs` |
+| 5 | DI registration | `Infrastructure/DependencyInjection.cs` |
+| 6 | `MigrateAsync()` extension method | `FeatureFlag.Api/Extensions/WebApplicationExtensions.cs` |
+| 7 | Startup wiring + Development guard | `FeatureFlag.Api/Program.cs` |
+
+No new endpoints. No changes to validators, DTOs, existing repository methods,
+or `FlagResponse`.
+
+---
+
+## Seed Records
+
+The seeder inserts the following six flags. They are designed to exercise all three
+rollout strategies across two environments — giving a developer or recruiter an
+immediately meaningful API to explore.
+
+| Name | Environment | Strategy | Enabled | StrategyConfig |
+|------|-------------|----------|---------|----------------|
+| `dark-mode` | Development | None | `true` | `"{}"` |
+| `new-dashboard` | Development | Percentage | `true` | `{"percentage":30}` |
+| `beta-features` | Development | RoleBased | `true` | `{"roles":["Admin","Beta"]}` |
+| `maintenance-mode` | Development | None | `false` | `"{}"` |
+| `dark-mode` | Staging | None | `true` | `"{}"` |
+| `new-dashboard` | Staging | Percentage | `true` | `{"percentage":50}` |
+
+All records are stamped `IsSeeded = true` at insert time.
+
+`StrategyConfig` is `"{}"` for all `None` strategy flags — this matches the value
+the domain stores after normalization. The manifest passes `"{}"` explicitly rather
+than `null` to avoid relying on normalization as an implicit side effect.
+
+---
+
+## Acceptance Criteria
+
+---
+
+### AC-1: IsSeeded Column and Migration
+
+**Files:**
+- `FeatureFlag.Domain/Entities/Flag.cs`
+- `FeatureFlag.Infrastructure/Persistence/FlagConfiguration.cs`
+- `FeatureFlag.Infrastructure/Persistence/Migrations/<timestamp>_AddIsSeededToFlag.cs`
+
+**Domain property:**
+- Add `public bool IsSeeded { get; private set; }` to the `Flag` entity
+- Default value: `false`
+- Not exposed on any DTO or API response — internal infrastructure concern only
+
+**EF Core mapping** (add to `FlagConfiguration.cs`):
+```csharp
+builder.Property(f => f.IsSeeded)
+    .IsRequired()
+    .HasDefaultValue(false);
+```
+
+**Migration:**
+- Generated via `dotnet ef migrations add AddIsSeededToFlag --project FeatureFlag.Infrastructure --startup-project FeatureFlag.Api`
+- Existing rows receive `IsSeeded = false` via the column default
+- Migration applies cleanly with no data loss
+- Migration must be generated against the running Postgres devcontainer
+  (`Host=postgres`) — not an in-memory provider
+
+---
+
+### AC-2: Flag Constructor Overload
+
+**File:** `FeatureFlag.Domain/Entities/Flag.cs`
+
+Add a second constructor overload that accepts `isSeeded`. The existing constructor
+signature is unchanged — all current callers continue to work without modification.
+
+```csharp
+// Existing constructor — unchanged, isSeeded defaults to false
+public Flag(
+    string name,
+    EnvironmentType environment,
+    bool isEnabled,
+    RolloutStrategy strategyType,
+    string? strategyConfig)
+    : this(name, environment, isEnabled, strategyType, strategyConfig, isSeeded: false)
+{ }
+
+// New overload — used by DatabaseSeeder only
+public Flag(
+    string name,
+    EnvironmentType environment,
+    bool isEnabled,
+    RolloutStrategy strategyType,
+    string? strategyConfig,
+    bool isSeeded)
+{
+    if (string.IsNullOrWhiteSpace(name))
+        throw new ArgumentException("Name cannot be empty.", nameof(name));
+
+    Name = name;
+    Environment = environment;
+    IsEnabled = isEnabled;
+    StrategyType = strategyType;
+    StrategyConfig = strategyConfig ?? "{}";
+    IsSeeded = isSeeded;
+}
+```
+
+The existing constructor delegates to the new one — no logic duplication.
+
+---
+
+### AC-3: DatabaseSeeder Class
+
+**File:** `FeatureFlag.Infrastructure/Seeding/DatabaseSeeder.cs`
+
+- Class is `internal sealed`
+- Constructor accepts `FeatureFlagDbContext` and `ILogger<DatabaseSeeder>`
+- Exposes a single public method: `Task SeedAsync(bool reset, CancellationToken ct = default)`
+- Does not reference any Application layer types
+- Does not reference `IFeatureFlagRepository`
+
+```csharp
+internal sealed class DatabaseSeeder(
+    FeatureFlagDbContext db,
+    ILogger<DatabaseSeeder> logger)
+{
+    public async Task SeedAsync(bool reset, CancellationToken ct = default)
+    { ... }
+}
+```
+
+---
+
+### AC-4: Normal Mode — Per-Record Backfill
+
+When `reset` is `false`:
+
+- Iterate over each record in the seed manifest
+- For each record, check whether an active (non-archived) flag exists in the slot
+  using `AnyAsync`:
+  ```csharp
+  await db.Flags.AnyAsync(
+      f => f.Name == record.Name
+        && f.Environment == record.Environment
+        && !f.IsArchived, ct);
+  ```
+- If an active row exists (seeded or manual) → skip, log at `Debug`:
+  `"Seed slot '{Name}' ({Environment}) is occupied — skipping."`
+- If no active row exists → construct `Flag` via the `isSeeded` constructor overload,
+  add to context
+- After processing all records, call `SaveChangesAsync` once
+- If any records were inserted → log at `Information`:
+  `"Seeded {Count} flag(s)."`
+- If all records were skipped → log at `Information`:
+  `"Seeding skipped — all seed slots are occupied."`
+
+**Archived seed flags are treated as empty slots** — the existence check filters
+`!IsArchived`, so an archived seeded flag is backfilled on next startup.
+
+---
+
+### AC-5: Reset Mode — Wipe Seeded Rows, Skip Collisions
+
+When `reset` is `true`:
+
+1. Log at `Warning` before delete:
+   `"SEED_RESET=true — deleting all seeded records before re-seeding."`
+
+2. Delete all rows where `IsSeeded = true`:
+   ```csharp
+   await db.Flags
+       .Where(f => f.IsSeeded)
+       .ExecuteDeleteAsync(ct);
+   ```
+
+3. For each manifest record, check whether a non-seeded active row occupies the slot:
+   ```csharp
+   await db.Flags.AnyAsync(
+       f => f.Name == record.Name
+         && f.Environment == record.Environment
+         && !f.IsArchived
+         && !f.IsSeeded, ct);
+   ```
+
+4. If a non-seeded active row occupies the slot → skip, log at `Warning`:
+   `"Seed slot '{Name}' ({Environment}) is occupied by a manual flag — skipping. Delete the manual flag and re-run SEED_RESET=true to restore this baseline slot."`
+
+5. If the slot is free → construct `Flag` via the `isSeeded` constructor overload,
+   add to context
+
+6. After processing all records, call `SaveChangesAsync` once
+
+7. Log at `Information` after insert:
+   `"Re-seeded {Count} flag(s)."`
+
+**Manual flags (`IsSeeded = false`) are never deleted under any circumstances.**
+
+---
+
+### AC-6: Startup Wiring in Program.cs
+
+**File:** `FeatureFlag.Api/Program.cs`
+
+Add the following block after `app.MapControllers()`:
+
+```csharp
+if (app.Environment.IsDevelopment())
+{
+    await app.MigrateAsync();
+
+    using var scope = app.Services.CreateScope();
+    var seeder = scope.ServiceProvider.GetRequiredService<DatabaseSeeder>();
+    var reset = Environment.GetEnvironmentVariable("SEED_RESET") == "true";
+    await seeder.SeedAsync(reset);
+}
+```
+
+- `MigrateAsync()` runs first — schema is guaranteed before seeding is attempted
+- `SEED_RESET` is read via `Environment.GetEnvironmentVariable()`, not
+  `IConfiguration` — keeps the reset signal separate from application config
+- The seeder is resolved from a new `IServiceScope` — required because
+  `DatabaseSeeder` depends on the scoped `FeatureFlagDbContext`
+
+**MigrateAsync extension method:**
+
+If `MigrateAsync()` does not exist as an extension on `WebApplication`, create it:
+
+**File:** `FeatureFlag.Api/Extensions/WebApplicationExtensions.cs`
+
+```csharp
+using FeatureFlag.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace FeatureFlag.Api.Extensions;
+
+internal static class WebApplicationExtensions
+{
+    internal static async Task MigrateAsync(this WebApplication app)
+    {
+        using var scope = app.Services.CreateScope();
+        var db = scope.ServiceProvider
+            .GetRequiredService<FeatureFlagDbContext>();
+        await db.Database.MigrateAsync();
+    }
+}
+```
+
+---
+
+### AC-7: DI Registration
+
+**File:** `FeatureFlag.Infrastructure/DependencyInjection.cs`
+
+Add to the `AddInfrastructure()` extension method:
+
+```csharp
+services.AddScoped<DatabaseSeeder>();
+```
+
+---
+
+### AC-8: Seed Record Coverage
+
+The seeder inserts exactly the six records defined in the [Seed Records](#seed-records)
+table. Each is constructed via the `Flag` constructor overload with `isSeeded: true`.
+
+Implementation pattern for each manifest record:
+
+```csharp
+new Flag(
+    name: "dark-mode",
+    environment: EnvironmentType.Development,
+    isEnabled: true,
+    strategyType: RolloutStrategy.None,
+    strategyConfig: "{}",
+    isSeeded: true)
+```
+
+---
+
+### AC-9: Logging
+
+All log messages use structured logging with named properties — no string
+interpolation.
+
+| Scenario | Level | Message Template |
+|----------|-------|-----------------|
+| Active row exists in slot (normal mode) | Debug | `"Seed slot '{Name}' ({Environment}) is occupied — skipping."` |
+| All slots occupied (normal mode) | Information | `"Seeding skipped — all seed slots are occupied."` |
+| Records inserted (normal mode) | Information | `"Seeded {Count} flag(s)."` |
+| Reset triggered | Warning | `"SEED_RESET=true — deleting all seeded records before re-seeding."` |
+| Slot occupied by manual flag (reset mode) | Warning | `"Seed slot '{Name}' ({Environment}) is occupied by a manual flag — skipping. Delete the manual flag and re-run SEED_RESET=true to restore this baseline slot."` |
+| Reset complete | Information | `"Re-seeded {Count} flag(s)."` |
+
+No user-identifying data is logged. Seed records contain no PII.
+
+---
+
+## File Layout
+
+```
+FeatureFlag.Domain/
+  Entities/
+    Flag.cs                                              ← modified (IsSeeded + constructor overload)
+
+FeatureFlag.Infrastructure/
+  Persistence/
+    FlagConfiguration.cs                                 ← modified (IsSeeded mapping)
+    Migrations/
+      <timestamp>_AddIsSeededToFlag.cs                   ← new
+  Seeding/
+    DatabaseSeeder.cs                                    ← new
+  DependencyInjection.cs                                 ← modified (register DatabaseSeeder)
+
+FeatureFlag.Api/
+  Extensions/
+    WebApplicationExtensions.cs                          ← new (MigrateAsync)
+  Program.cs                                             ← modified (Development block)
+```
+
+---
+
+## Implementation Notes
+
+- `ExecuteDeleteAsync` requires EF Core 7+. Already available (EF Core 10).
+- `IsSeeded` must not appear on `FlagResponse` or any other DTO. The column is
+  an internal infrastructure concern — API consumers have no knowledge of it.
+- The seeder calls `FeatureFlagDbContext` directly — do not route through
+  `IFeatureFlagRepository`. The repository is the Application layer's boundary.
+- The manifest literals are trusted constant data defined by the engineer —
+  `InputSanitizer` is not required. The sanitization rule applies to untrusted
+  HTTP input surfaces only.
+- `SaveChangesAsync` is called once per mode (after all inserts in normal mode;
+  after all inserts in reset mode) — not once per record.
+- The migration must be generated against the running Postgres devcontainer —
+  not an in-memory provider. Use the devcontainer terminal and confirm
+  `Host=postgres` is set in `appsettings.Development.json`.
+- CSharpier formatting must pass — run `dotnet csharpier .` before committing.
+
+---
+
+## Out of Scope
+
+- Seed data for Staging or Production environments
+- A dedicated reset CLI command or API endpoint
+- Changes to existing validators, DTOs, or repository methods
+- Exposing `IsSeeded` on any API response
+- Seed data for integration tests — test data is owned by each test class
+  via Testcontainers setup
+
+---
+
+## Definition of Done
+
+- [ ] `IsSeeded` property exists on `Flag` entity with `private` setter, default `false`
+- [ ] `Flag` constructor overload accepting `isSeeded` exists; existing constructor unchanged
+- [ ] EF Core column mapping added to `FlagConfiguration.cs`
+- [ ] Migration generated, applies cleanly, existing rows receive `IsSeeded = false`
+- [ ] `DatabaseSeeder` exists at `Infrastructure/Seeding/DatabaseSeeder.cs`
+- [ ] `DatabaseSeeder` registered as scoped in `AddInfrastructure()`
+- [ ] `MigrateAsync()` extension exists in `FeatureFlag.Api/Extensions/`
+- [ ] `MigrateAsync()` called before seeder in the Development startup block
+- [ ] Seeder invoked inside `IsDevelopment()` guard in `Program.cs`
+- [ ] Normal mode is per-record — backfills empty or archived slots only
+- [ ] Reset mode deletes only `IsSeeded = true` rows — manual flags never touched
+- [ ] Reset mode skips and logs slots occupied by non-seeded active flags
+- [ ] All six seed records inserted covering all three strategies and two environments
+- [ ] Every seeder-inserted row stamped `IsSeeded = true`
+- [ ] `IsSeeded` not present on any DTO or API response
+- [ ] All log messages use structured logging with named properties
+- [ ] `dotnet build` passes with 0 warnings, 0 errors
+- [ ] All 110 existing tests still pass
+- [ ] CSharpier check passes

--- a/Docs/Decisions/seed-data - PR###/spec.md
+++ b/Docs/Decisions/seed-data - PR###/spec.md
@@ -1,0 +1,362 @@
+# Specification: Seed Data for Local Development
+
+**Document:** `Docs/Decisions/seed-data/spec.md`
+**Branch:** `feature/phase1-finish-line`
+**Phase:** 1 — Developer Experience
+**Status:** Ready for Implementation
+**Author:** Jose / Claude Architect Session
+**Date:** 2026-04-13
+
+---
+
+## Table of Contents
+
+- [User Story](#user-story)
+- [Background & Goals](#background--goals)
+- [Design Decisions](#design-decisions)
+  - [DD-1: Automatic Startup Seeding, Development Only](#dd-1-automatic-startup-seeding-development-only)
+  - [DD-2: Idempotency — Skip if Data Exists](#dd-2-idempotency--skip-if-data-exists)
+  - [DD-3: Reset Mode via Environment Variable](#dd-3-reset-mode-via-environment-variable)
+  - [DD-4: Layer Placement](#dd-4-layer-placement)
+- [Scope](#scope)
+- [Seed Records](#seed-records)
+- [Acceptance Criteria](#acceptance-criteria)
+  - [AC-1: DatabaseSeeder Class](#ac-1-databaseseeder-class)
+  - [AC-2: Normal Mode — Idempotent Insert](#ac-2-normal-mode--idempotent-insert)
+  - [AC-3: Reset Mode — Wipe and Re-seed](#ac-3-reset-mode--wipe-and-re-seed)
+  - [AC-4: Environment Guard](#ac-4-environment-guard)
+  - [AC-5: Startup Wiring in Program.cs](#ac-5-startup-wiring-in-programcs)
+  - [AC-6: Seed Record Coverage](#ac-6-seed-record-coverage)
+  - [AC-7: Logging](#ac-7-logging)
+- [File Layout](#file-layout)
+- [Implementation Notes](#implementation-notes)
+- [Out of Scope](#out-of-scope)
+- [Definition of Done](#definition-of-done)
+
+---
+
+## User Story
+
+> As a developer (or recruiter evaluating this project), I want a working set of
+> feature flags automatically available when I run `docker compose up` — so I can
+> explore and test the API immediately without any manual database setup.
+
+---
+
+## Background & Goals
+
+Currently, a developer who clones the repo and starts the app has an empty database.
+Every manual test requires creating flags by hand before anything meaningful can be
+evaluated. This creates two problems:
+
+1. **Onboarding friction** — new developers and recruiters cannot immediately explore
+   the API. The "15-minute demo" promise in the product vision is broken.
+
+2. **Dev data rot** — developers who have been working for days or weeks accumulate
+   test data that no longer reflects a known clean state. There is no way to reset
+   to a baseline without manually deleting rows.
+
+This spec introduces a `DatabaseSeeder` that solves both problems: it seeds a
+curated set of representative flags on startup (Development only), and supports a
+controlled reset when a developer needs a clean slate.
+
+---
+
+## Design Decisions
+
+### DD-1: Automatic Startup Seeding, Development Only
+
+The seeder runs automatically during application startup. No manual CLI step is
+required. This preserves the `docker compose up` onboarding experience described
+in the product vision.
+
+The seeder is **guarded by `IHostEnvironment.IsDevelopment()`**. It will not run
+in Staging or Production under any circumstances. This makes the feature safe to
+ship without additional configuration management.
+
+**Rejected alternative — EF Core `HasData()`:** `HasData()` is baked into
+migrations and runs in all environments unless carefully managed. It also cannot
+support reset logic or environment-conditional behavior without significant
+workarounds. Not appropriate for this use case.
+
+**Rejected alternative — CLI command only:** Requires a manual step after startup,
+breaking the `docker compose up` onboarding flow.
+
+---
+
+### DD-2: Idempotency — Skip if Data Exists
+
+On every startup, the seeder checks whether seed records already exist before
+inserting. If any seed records are found, seeding is skipped entirely. Running
+the app twice produces the same database state as running it once.
+
+The existence check is performed by flag name — if a flag with the seed name
+already exists (including archived), the insert for that record is skipped.
+
+---
+
+### DD-3: Reset Mode via Environment Variable
+
+A developer who needs a clean slate can trigger a full reset by setting the
+environment variable `SEED_RESET=true` before starting the app. In reset mode:
+
+1. All existing seed records are deleted (matched by name from the seed manifest)
+2. The full seed set is re-inserted from scratch
+
+Reset is scoped to seed records only — flags created manually by developers are
+not touched.
+
+The variable is passable via Docker Compose without modifying source code:
+
+```bash
+SEED_RESET=true docker compose up
+```
+
+Or declared temporarily in `docker-compose.override.yml` for a session.
+
+---
+
+### DD-4: Layer Placement
+
+| Concern | Layer | Location |
+|---------|-------|----------|
+| `DatabaseSeeder` class | Infrastructure | `Infrastructure/Seeding/DatabaseSeeder.cs` |
+| Startup trigger | Api | `Program.cs` |
+
+The seeder belongs in Infrastructure because it has a direct dependency on
+`AppDbContext` (EF Core). The Api layer owns `Program.cs` and is responsible for
+calling the seeder during startup orchestration.
+
+---
+
+## Scope
+
+| # | What | File(s) Affected |
+|---|------|-----------------|
+| 1 | `DatabaseSeeder` class | `Infrastructure/Seeding/DatabaseSeeder.cs` |
+| 2 | Startup wiring | `FeatureFlag.Api/Program.cs` |
+| 3 | Seed record manifest (inline) | `Infrastructure/Seeding/DatabaseSeeder.cs` |
+
+No new migrations. No new DTOs. No new endpoints. No changes to existing domain
+logic or validators.
+
+---
+
+## Seed Records
+
+The seeder inserts the following flags. They are designed to exercise all three
+rollout strategies across multiple environments — giving a developer or recruiter
+an immediately meaningful API to explore.
+
+| Name | Environment | Strategy | Enabled | Notes |
+|------|-------------|----------|---------|-------|
+| `dark-mode` | Development | None | `true` | Simple on/off flag |
+| `new-dashboard` | Development | Percentage | `true` | 30% rollout |
+| `beta-features` | Development | RoleBased | `true` | Admin and Beta roles |
+| `maintenance-mode` | Development | None | `false` | Disabled flag example |
+| `dark-mode` | Staging | None | `true` | Cross-environment demo |
+| `new-dashboard` | Staging | Percentage | `true` | 50% rollout in Staging |
+
+---
+
+## Acceptance Criteria
+
+---
+
+### AC-1: DatabaseSeeder Class
+
+**File:** `FeatureFlag.Infrastructure/Seeding/DatabaseSeeder.cs`
+
+- Class is `internal sealed`
+- Constructor accepts `AppDbContext` and `ILogger<DatabaseSeeder>`
+- Exposes a single public method: `Task SeedAsync(bool reset, CancellationToken ct)`
+- Does not reference any Application layer types — uses EF Core directly
+
+```csharp
+internal sealed class DatabaseSeeder(
+    AppDbContext db,
+    ILogger<DatabaseSeeder> logger)
+{
+    public async Task SeedAsync(bool reset, CancellationToken ct = default)
+    { ... }
+}
+```
+
+---
+
+### AC-2: Normal Mode — Idempotent Insert
+
+When `reset` is `false`:
+
+- For each seed record, check if a flag with that name and environment already
+  exists in the database (including archived flags)
+- If it exists → skip that record, log at `Debug` level:
+  `"Seed record '{Name}' ({Environment}) already exists — skipping."`
+- If it does not exist → insert and save
+- If all records already exist → log at `Information` level:
+  `"Seeding skipped — all seed records already present."`
+- If any records were inserted → log at `Information` level:
+  `"Seeded {Count} flag(s)."`
+
+The check uses `AnyAsync` on `AppDbContext.Flags` filtered by `Name` and
+`Environment`. It does **not** use the repository — the seeder calls `DbContext`
+directly.
+
+---
+
+### AC-3: Reset Mode — Wipe and Re-seed
+
+When `reset` is `true`:
+
+- Collect the names of all seed records from the manifest
+- Delete all flags from the database whose `Name` is in the seed manifest AND
+  whose `Environment` matches — using `ExecuteDeleteAsync` for efficiency
+- Re-insert all seed records unconditionally
+- Log at `Warning` level before delete:
+  `"SEED_RESET=true — deleting existing seed records before re-seeding."`
+- Log at `Information` level after insert:
+  `"Re-seeded {Count} flag(s)."`
+
+Reset is scoped to seed records only. Flags not in the seed manifest are
+untouched regardless of reset mode.
+
+---
+
+### AC-4: Environment Guard
+
+**File:** `FeatureFlag.Api/Program.cs`
+
+- The seeder is only invoked if `app.Environment.IsDevelopment()` returns `true`
+- If not in Development, no seeding code executes and no log output is produced
+  related to seeding
+- The guard is applied at the call site in `Program.cs`, not inside `DatabaseSeeder`
+  itself — the seeder has no knowledge of environment
+
+```csharp
+if (app.Environment.IsDevelopment())
+{
+    using var scope = app.Services.CreateScope();
+    var seeder = scope.ServiceProvider.GetRequiredService<DatabaseSeeder>();
+    var reset = Environment.GetEnvironmentVariable("SEED_RESET") == "true";
+    await seeder.SeedAsync(reset);
+}
+```
+
+---
+
+### AC-5: Startup Wiring in Program.cs
+
+- `DatabaseSeeder` is registered in DI as a scoped service in
+  `Infrastructure/DependencyInjection.cs` (the `AddInfrastructure()` extension method)
+- Registration:
+
+```csharp
+services.AddScoped<DatabaseSeeder>();
+```
+
+- `SeedAsync` is called after `app.MapControllers()` and after
+  `await app.MigrateAsync()` (if a migration helper exists) — seeding always
+  runs on a fully migrated schema
+- The call site in `Program.cs` creates a scoped `IServiceProvider` via
+  `app.Services.CreateScope()` to resolve the scoped `DatabaseSeeder`
+
+---
+
+### AC-6: Seed Record Coverage
+
+The seeder inserts exactly the six records defined in the [Seed Records](#seed-records)
+table above. Each record must be constructed as a valid `Flag` entity using the
+domain's existing factory or constructor — not via raw SQL or object initializers
+that bypass domain invariants.
+
+Seed record `StrategyConfig` values:
+
+| Name | Environment | StrategyConfig |
+|------|-------------|----------------|
+| `dark-mode` | Development | `null` |
+| `new-dashboard` | Development | `{"percentage":30}` |
+| `beta-features` | Development | `{"roles":["Admin","Beta"]}` |
+| `maintenance-mode` | Development | `null` |
+| `dark-mode` | Staging | `null` |
+| `new-dashboard` | Staging | `{"percentage":50}` |
+
+`StrategyConfig` is `null` for `None` strategy flags (consistent with the wire
+contract established in PR #37).
+
+---
+
+### AC-7: Logging
+
+All log messages produced by the seeder use structured logging with named
+properties — no string interpolation.
+
+| Scenario | Level | Message Template |
+|----------|-------|-----------------|
+| Record already exists (per record) | Debug | `"Seed record '{Name}' ({Environment}) already exists — skipping."` |
+| All records already present | Information | `"Seeding skipped — all seed records already present."` |
+| Records inserted | Information | `"Seeded {Count} flag(s)."` |
+| Reset triggered | Warning | `"SEED_RESET=true — deleting existing seed records before re-seeding."` |
+| Reset complete | Information | `"Re-seeded {Count} flag(s)."` |
+
+No raw user data is logged. Seed records contain no user-identifying information.
+
+---
+
+## File Layout
+
+```
+FeatureFlag.Infrastructure/
+  Seeding/
+    DatabaseSeeder.cs         ← new
+
+FeatureFlag.Api/
+  Program.cs                  ← modified (environment guard + seeder call)
+
+FeatureFlag.Infrastructure/
+  DependencyInjection.cs      ← modified (register DatabaseSeeder as scoped)
+```
+
+---
+
+## Implementation Notes
+
+- The seeder uses `AppDbContext` directly — do not route through
+  `IFeatureFlagRepository`. The repository interface is the Application layer's
+  boundary; the seeder lives in Infrastructure and may call `DbContext` directly.
+- `ExecuteDeleteAsync` requires EF Core 7+. Already available in this project
+  (EF Core 10).
+- The seeder must await each `SaveChangesAsync` call. Do not batch inserts across
+  environments in a single `SaveChanges` call — insert and save per record or per
+  batch to keep error attribution clear.
+- Do not call `HasData()` in any migration as part of this work.
+- The `SEED_RESET` env var is read via `Environment.GetEnvironmentVariable()` at
+  the `Program.cs` call site — not injected via `IConfiguration`. This keeps the
+  reset signal clearly separated from application configuration.
+- CSharpier formatting must pass — run `dotnet csharpier .` before committing.
+
+---
+
+## Out of Scope
+
+- Seed data for Staging or Production environments
+- A dedicated reset CLI command
+- Any new API endpoint for triggering seed or reset
+- Changes to existing migrations
+- Seed data for integration tests — test data is owned by each test class via
+  Testcontainers setup
+
+---
+
+## Definition of Done
+
+- [ ] `DatabaseSeeder` exists at `Infrastructure/Seeding/DatabaseSeeder.cs`
+- [ ] `DatabaseSeeder` is registered as scoped in `AddInfrastructure()`
+- [ ] Seeder is called in `Program.cs` inside an `IsDevelopment()` guard
+- [ ] Normal mode is idempotent — running the app twice does not duplicate records
+- [ ] Reset mode deletes and re-inserts all seed records when `SEED_RESET=true`
+- [ ] Reset does not touch flags outside the seed manifest
+- [ ] All six seed records are inserted covering all three strategies
+- [ ] All log messages use structured logging with named properties
+- [ ] `dotnet build` passes with 0 warnings, 0 errors
+- [ ] `dotnet test` — all 110 existing tests still pass
+- [ ] CSharpier check passes

--- a/FeatureFlag.Api/Extensions/WebApplicationExtensions.cs
+++ b/FeatureFlag.Api/Extensions/WebApplicationExtensions.cs
@@ -1,0 +1,14 @@
+using FeatureFlag.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace FeatureFlag.Api.Extensions;
+
+internal static class WebApplicationExtensions
+{
+    internal static async Task MigrateAsync(this WebApplication app)
+    {
+        using IServiceScope scope = app.Services.CreateScope();
+        FeatureFlagDbContext db = scope.ServiceProvider.GetRequiredService<FeatureFlagDbContext>();
+        await db.Database.MigrateAsync();
+    }
+}

--- a/FeatureFlag.Api/Program.cs
+++ b/FeatureFlag.Api/Program.cs
@@ -1,6 +1,8 @@
+using FeatureFlag.Api.Extensions;
 using FeatureFlag.Api.OpenApi;
 using FeatureFlag.Application;
 using FeatureFlag.Infrastructure;
+using FeatureFlag.Infrastructure.Seeding;
 using Scalar.AspNetCore;
 
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
@@ -40,6 +42,16 @@ if (app.Environment.IsDevelopment())
 app.UseHttpsRedirection();
 app.UseAuthorization();
 app.MapControllers();
+
+if (app.Environment.IsDevelopment())
+{
+    await app.MigrateAsync();
+
+    using IServiceScope scope = app.Services.CreateScope();
+    DatabaseSeeder seeder = scope.ServiceProvider.GetRequiredService<DatabaseSeeder>();
+    bool reset = Environment.GetEnvironmentVariable("SEED_RESET") == "true";
+    await seeder.SeedAsync(reset);
+}
 
 app.Run();
 

--- a/FeatureFlag.Domain/Entities/Flag.cs
+++ b/FeatureFlag.Domain/Entities/Flag.cs
@@ -9,6 +9,7 @@ public class Flag
     public EnvironmentType Environment { get; private set; }
     public bool IsEnabled { get; private set; }
     public bool IsArchived { get; private set; }
+    public bool IsSeeded { get; private set; }
     public RolloutStrategy StrategyType { get; private set; }
     public string StrategyConfig { get; private set; }
     public DateTime CreatedAt { get; private set; } = DateTime.UtcNow;
@@ -22,6 +23,16 @@ public class Flag
         RolloutStrategy strategyType,
         string? strategyConfig
     )
+        : this(name, environment, isEnabled, strategyType, strategyConfig, isSeeded: false) { }
+
+    public Flag(
+        string name,
+        EnvironmentType environment,
+        bool isEnabled,
+        RolloutStrategy strategyType,
+        string? strategyConfig,
+        bool isSeeded
+    )
     {
         if (string.IsNullOrWhiteSpace(name))
         {
@@ -33,6 +44,7 @@ public class Flag
         IsEnabled = isEnabled;
         StrategyType = strategyType;
         StrategyConfig = strategyConfig ?? "{}";
+        IsSeeded = isSeeded;
     }
 
     // Required by EF Core

--- a/FeatureFlag.Infrastructure/DependencyInjection.cs
+++ b/FeatureFlag.Infrastructure/DependencyInjection.cs
@@ -1,5 +1,6 @@
 using FeatureFlag.Domain.Interfaces;
 using FeatureFlag.Infrastructure.Persistence;
+using FeatureFlag.Infrastructure.Seeding;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -18,6 +19,7 @@ public static class DependencyInjection
         );
 
         services.AddScoped<IFeatureFlagRepository, FeatureFlagRepository>();
+        services.AddScoped<DatabaseSeeder>();
 
         return services;
     }

--- a/FeatureFlag.Infrastructure/Migrations/20260413213416_AddIsSeededToFlag.Designer.cs
+++ b/FeatureFlag.Infrastructure/Migrations/20260413213416_AddIsSeededToFlag.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using FeatureFlag.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace FeatureFlag.Infrastructure.Migrations
 {
     [DbContext(typeof(FeatureFlagDbContext))]
-    partial class FeatureFlagDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260413213416_AddIsSeededToFlag")]
+    partial class AddIsSeededToFlag
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/FeatureFlag.Infrastructure/Migrations/20260413213416_AddIsSeededToFlag.cs
+++ b/FeatureFlag.Infrastructure/Migrations/20260413213416_AddIsSeededToFlag.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace FeatureFlag.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddIsSeededToFlag : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsSeeded",
+                table: "flags",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsSeeded",
+                table: "flags");
+        }
+    }
+}

--- a/FeatureFlag.Infrastructure/Persistence/FlagConfiguration.cs
+++ b/FeatureFlag.Infrastructure/Persistence/FlagConfiguration.cs
@@ -24,6 +24,8 @@ public sealed class FlagConfiguration : IEntityTypeConfiguration<Flag>
 
         builder.Property(f => f.IsArchived).IsRequired();
 
+        builder.Property(f => f.IsSeeded).IsRequired().HasDefaultValue(false);
+
         builder.Property(f => f.CreatedAt).IsRequired();
 
         builder.Property(f => f.UpdatedAt).IsRequired();

--- a/FeatureFlag.Infrastructure/Seeding/DatabaseSeeder.cs
+++ b/FeatureFlag.Infrastructure/Seeding/DatabaseSeeder.cs
@@ -1,0 +1,143 @@
+using FeatureFlag.Domain.Entities;
+using FeatureFlag.Domain.Enums;
+using FeatureFlag.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace FeatureFlag.Infrastructure.Seeding;
+
+public sealed class DatabaseSeeder(FeatureFlagDbContext db, ILogger<DatabaseSeeder> logger)
+{
+    private static readonly SeedRecord[] SeedManifest =
+    [
+        new("dark-mode", EnvironmentType.Development, true, RolloutStrategy.None, "{}"),
+        new(
+            "new-dashboard",
+            EnvironmentType.Development,
+            true,
+            RolloutStrategy.Percentage,
+            """{"percentage":30}"""
+        ),
+        new(
+            "beta-features",
+            EnvironmentType.Development,
+            true,
+            RolloutStrategy.RoleBased,
+            """{"roles":["Admin","Beta"]}"""
+        ),
+        new("maintenance-mode", EnvironmentType.Development, false, RolloutStrategy.None, "{}"),
+        new("dark-mode", EnvironmentType.Staging, true, RolloutStrategy.None, "{}"),
+        new(
+            "new-dashboard",
+            EnvironmentType.Staging,
+            true,
+            RolloutStrategy.Percentage,
+            """{"percentage":50}"""
+        ),
+    ];
+
+    public async Task SeedAsync(bool reset, CancellationToken ct = default)
+    {
+        if (reset)
+        {
+            await ResetSeedAsync(ct);
+            return;
+        }
+
+        await SeedMissingAsync(ct);
+    }
+
+    private async Task SeedMissingAsync(CancellationToken ct)
+    {
+        int insertedCount = 0;
+
+        foreach (SeedRecord record in SeedManifest)
+        {
+            bool slotOccupied = await db.Flags.AnyAsync(
+                f => f.Name == record.Name && f.Environment == record.Environment && !f.IsArchived,
+                ct
+            );
+
+            if (slotOccupied)
+            {
+                if (logger.IsEnabled(LogLevel.Debug))
+                {
+                    logger.LogDebug(
+                        "Seed slot '{Name}' ({Environment}) is occupied - skipping.",
+                        record.Name,
+                        record.Environment
+                    );
+                }
+
+                continue;
+            }
+
+            await db.Flags.AddAsync(record.ToFlag(), ct);
+            insertedCount++;
+        }
+
+        if (insertedCount == 0)
+        {
+            logger.LogInformation("Seeding skipped - all seed slots are occupied.");
+            return;
+        }
+
+        await db.SaveChangesAsync(ct);
+        if (logger.IsEnabled(LogLevel.Information))
+        {
+            logger.LogInformation("Seeded {Count} flag(s).", insertedCount);
+        }
+    }
+
+    private async Task ResetSeedAsync(CancellationToken ct)
+    {
+        logger.LogWarning("SEED_RESET=true - deleting all seeded records before re-seeding.");
+
+        await db.Flags.Where(f => f.IsSeeded).ExecuteDeleteAsync(ct);
+
+        int insertedCount = 0;
+
+        foreach (SeedRecord record in SeedManifest)
+        {
+            bool manualSlotOccupied = await db.Flags.AnyAsync(
+                f =>
+                    f.Name == record.Name
+                    && f.Environment == record.Environment
+                    && !f.IsArchived
+                    && !f.IsSeeded,
+                ct
+            );
+
+            if (manualSlotOccupied)
+            {
+                logger.LogWarning(
+                    "Seed slot '{Name}' ({Environment}) is occupied by a manual flag - skipping. Delete the manual flag and re-run SEED_RESET=true to restore this baseline slot.",
+                    record.Name,
+                    record.Environment
+                );
+                continue;
+            }
+
+            await db.Flags.AddAsync(record.ToFlag(), ct);
+            insertedCount++;
+        }
+
+        await db.SaveChangesAsync(ct);
+        if (logger.IsEnabled(LogLevel.Information))
+        {
+            logger.LogInformation("Re-seeded {Count} flag(s).", insertedCount);
+        }
+    }
+
+    private sealed record SeedRecord(
+        string Name,
+        EnvironmentType Environment,
+        bool IsEnabled,
+        RolloutStrategy StrategyType,
+        string StrategyConfig
+    )
+    {
+        public Flag ToFlag() =>
+            new(Name, Environment, IsEnabled, StrategyType, StrategyConfig, isSeeded: true);
+    }
+}

--- a/FeatureFlag.Tests.Integration/SeedDataStartupTests.cs
+++ b/FeatureFlag.Tests.Integration/SeedDataStartupTests.cs
@@ -1,0 +1,48 @@
+using FeatureFlag.Infrastructure.Persistence;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace FeatureFlag.Tests.Integration;
+
+[Trait("Category", "Integration")]
+public sealed class SeedDataStartupTests
+{
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task ApplicationStartup_SeedsBaselineFlagsAsync()
+    {
+        var factory = new Fixtures.FeatureFlagApiFactory();
+        await factory.InitializeAsync();
+
+        try
+        {
+            using IServiceScope scope = factory.Services.CreateScope();
+            FeatureFlagDbContext dbContext =
+                scope.ServiceProvider.GetRequiredService<FeatureFlagDbContext>();
+
+            List<FeatureFlag.Domain.Entities.Flag> seededFlags = await dbContext
+                .Flags.OrderBy(f => f.Environment)
+                .ThenBy(f => f.Name)
+                .ToListAsync();
+
+            seededFlags.Should().HaveCount(6);
+            seededFlags.Should().OnlyContain(flag => flag.IsSeeded);
+            seededFlags
+                .Select(flag => (flag.Name, flag.Environment))
+                .Should()
+                .BeEquivalentTo([
+                    ("beta-features", Domain.Enums.EnvironmentType.Development),
+                    ("dark-mode", Domain.Enums.EnvironmentType.Development),
+                    ("maintenance-mode", Domain.Enums.EnvironmentType.Development),
+                    ("new-dashboard", Domain.Enums.EnvironmentType.Development),
+                    ("dark-mode", Domain.Enums.EnvironmentType.Staging),
+                    ("new-dashboard", Domain.Enums.EnvironmentType.Staging),
+                ]);
+        }
+        finally
+        {
+            await factory.DisposeAsync();
+        }
+    }
+}

--- a/FeatureFlag.Tests/Domain/FlagTests.cs
+++ b/FeatureFlag.Tests/Domain/FlagTests.cs
@@ -1,0 +1,40 @@
+using FeatureFlag.Domain.Entities;
+using FeatureFlag.Domain.Enums;
+
+namespace FeatureFlag.Tests.Domain;
+
+[Trait("Category", "Unit")]
+public sealed class FlagTests
+{
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Constructor_WithoutIsSeededParameter_DefaultsToFalse()
+    {
+        var flag = new Flag(
+            "dark-mode",
+            EnvironmentType.Development,
+            isEnabled: true,
+            RolloutStrategy.None,
+            strategyConfig: null
+        );
+
+        Assert.False(flag.IsSeeded);
+        Assert.Equal("{}", flag.StrategyConfig);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Constructor_WithIsSeededParameter_SetsSeededState()
+    {
+        var flag = new Flag(
+            "dark-mode",
+            EnvironmentType.Development,
+            isEnabled: true,
+            RolloutStrategy.None,
+            strategyConfig: "{}",
+            isSeeded: true
+        );
+
+        Assert.True(flag.IsSeeded);
+    }
+}


### PR DESCRIPTION
## Summary
- add development-only startup seeding with `IsSeeded` provenance, reset support, and collision-safe baseline slot handling
- run EF migrations before seeding and persist the new `IsSeeded` column via a generated migration against Postgres
- add focused unit and integration coverage for seeded flag creation and startup baseline seeding

## Test plan
- [x] `dotnet csharpier check .`
- [x] `dotnet build FeatureFlagService.sln -p:TreatWarningsAsErrors=true`
- [x] `dotnet test FeatureFlagService.sln`
- [x] `dotnet ef database update --project "FeatureFlag.Infrastructure" --startup-project "FeatureFlag.Api" --connection "Host=postgres;Port=5432;Database=featureflags;Username=postgres;Password=postgres"`