### PR TITLE
feat: integrate Application Insights telemetry

### DIFF
--- a/Banderas.Api/Banderas.Api.csproj
+++ b/Banderas.Api/Banderas.Api.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.*" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.*" />
     <PackageReference Include="Azure.Identity" Version="1.*" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.5" />
     <PackageReference Include="Scalar.AspNetCore" Version="2.*" />

--- a/Banderas.Api/Program.cs
+++ b/Banderas.Api/Program.cs
@@ -30,8 +30,9 @@ builder.Services.AddOpenApi(options =>
     options.AddDocumentTransformer<ApiInfoTransformer>();
 });
 
+builder.Services.AddApplicationInsightsTelemetry();
 builder.Services.AddApplication();
-builder.Services.AddInfrastructure(builder.Configuration);
+builder.Services.AddInfrastructure(builder.Configuration, builder.Environment);
 
 WebApplication app = builder.Build();
 

--- a/Banderas.Api/appsettings.json
+++ b/Banderas.Api/appsettings.json
@@ -8,5 +8,8 @@
   "AllowedHosts": "*",
   "Azure": {
     "KeyVaultUri": ""
+  },
+  "ApplicationInsights": {
+    "ConnectionString": ""
   }
 }

--- a/Banderas.Api/packages.lock.json
+++ b/Banderas.Api/packages.lock.json
@@ -22,6 +22,21 @@
           "Azure.Core": "1.53.0"
         }
       },
+      "Microsoft.ApplicationInsights.AspNetCore": {
+        "type": "Direct",
+        "requested": "[2.*, )",
+        "resolved": "2.23.0",
+        "contentHash": "we/RsIn0Mwf/4ZNGXZixJ0lVD3pqjx2yVeKfqJybgYY/Lib8nnf+8YGJp+ULN3kOk39I0pI/7ZnF9LFy6hS3lw==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.23.0",
+          "Microsoft.ApplicationInsights.DependencyCollector": "2.23.0",
+          "Microsoft.ApplicationInsights.EventCounterCollector": "2.23.0",
+          "Microsoft.ApplicationInsights.PerfCounterCollector": "2.23.0",
+          "Microsoft.ApplicationInsights.WindowsServer": "2.23.0",
+          "Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel": "2.23.0",
+          "Microsoft.Extensions.Logging.ApplicationInsights": "2.23.0"
+        }
+      },
       "Microsoft.AspNetCore.OpenApi": {
         "type": "Direct",
         "requested": "[10.0.5, )",
@@ -83,6 +98,56 @@
         "type": "Transitive",
         "resolved": "2.14.1",
         "contentHash": "lQKvtaTDOXnoVJ20ibTuSIOf2i0uO0MPbDhd1jm238I+U/2ZnRENj0cktKZhtchBMtCUSRQ5v4xBCUbKNmyVMw=="
+      },
+      "Microsoft.ApplicationInsights": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "nWArUZTdU7iqZLycLKWe0TDms48KKGE6pONH2terYNa8REXiqixrMOkf1sk5DHGMaUTqONU2YkS4SAXBhLStgw=="
+      },
+      "Microsoft.ApplicationInsights.DependencyCollector": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "9YRdl9SNbTxd4AafJckyoJLr5gJdnvqFivjo+PY0lQTPEncPB+z3ZABG4iDfxN9HI1aLqyRINr1/7de9Wg8ZuQ==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.23.0"
+        }
+      },
+      "Microsoft.ApplicationInsights.EventCounterCollector": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "gGt0JPw2dcSeIAIefyORJBdeMz8KgAFIktu8HV/NwkiGmLyw+YtifLm6B5gvGxO15AeMsGPbmvWEIvLfq88XPw==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.23.0"
+        }
+      },
+      "Microsoft.ApplicationInsights.PerfCounterCollector": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "q9ApjZfBS9O8m3aQM2oVjsGBmlE8BCFywT7UR+8aqdNuz7HpoIxw4jHy0XOBergiFX/olrJF4OyPkGxc3H5JHg==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.23.0",
+          "System.Diagnostics.PerformanceCounter": "6.0.0"
+        }
+      },
+      "Microsoft.ApplicationInsights.WindowsServer": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "2B8CGfnB/tribkQAqRBhMvJYJK5TkEPMG/BB0QrlxdwVGEufayNLMveXjkQCqld9arXd6wKR1ve2XmkA0+xXKQ==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.23.0",
+          "Microsoft.ApplicationInsights.DependencyCollector": "2.23.0",
+          "Microsoft.ApplicationInsights.PerfCounterCollector": "2.23.0",
+          "Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel": "2.23.0"
+        }
+      },
+      "Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "798Dudr4tkujslk1w+XcXOcCErmVsk+nhp+QCHLa3lcgi25vkAxBmzPUeQlRJVCNL/1f4x/YF+vQZ8RSuTXWCw==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.23.0",
+          "System.IO.FileSystem.AccessControl": "4.7.0"
+        }
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
@@ -186,6 +251,14 @@
         "resolved": "10.0.4",
         "contentHash": "LiJXylfk8pk+2zsUsITkou3QTFMJ8RNJ0oKKY0Oyjt6HJctGJwPw//ZgoNO4J29zKaT+dR4/PI2jW/znRcspLg=="
       },
+      "Microsoft.Extensions.Logging.ApplicationInsights": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "JLEabPz445i1yRB0hKZVzJJE35QatRIzWlrMOiBQXr9kBJod0jkpkrBf94ln6kXu+jlEGohnXtuXacPPhybJDw==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.23.0"
+        }
+      },
       "Microsoft.Identity.Client": {
         "type": "Transitive",
         "resolved": "4.83.1",
@@ -217,6 +290,11 @@
         "type": "Transitive",
         "resolved": "1.0.52",
         "contentHash": "oNv2JtYXhpdJrX63nibx1JT3uCESOBQ1LAk7Dtz/sr0+laW0KRM6eKp4CZ3MHDR2siIkKsY8MmUkeP5DKkQQ5w=="
+      },
+      "Microsoft.Win32.SystemEvents": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "hqTM5628jSsQiv+HGpiq3WKBl2c8v1KZfby2J6Pr7pEPlK9waPdgEO6b8A/+/xn/yZ9ulv8HuqK71ONy2tg67A=="
       },
       "Mono.TextTemplating": {
         "type": "Transitive",
@@ -307,6 +385,36 @@
           "System.Composition.Runtime": "9.0.0"
         }
       },
+      "System.Configuration.ConfigurationManager": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "7T+m0kDSlIPTHIkPMIu6m6tV6qsMqJpvQWW2jIc2qi7sn40qxFo0q+7mEQAhMPXZHMKnWrnv47ntGlM/ejvw3g==",
+        "dependencies": {
+          "System.Security.Cryptography.ProtectedData": "6.0.0",
+          "System.Security.Permissions": "6.0.0"
+        }
+      },
+      "System.Diagnostics.PerformanceCounter": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "gbeE5tNp/oB7O8kTTLh3wPPJCxpNOphXPTWVs1BsYuFOYapFijWuh0LYw1qnDo4gwDUYPXOmpTIhvtxisGsYOQ==",
+        "dependencies": {
+          "System.Configuration.ConfigurationManager": "6.0.0"
+        }
+      },
+      "System.Drawing.Common": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "NfuoKUiP2nUWwKZN6twGqXioIe1zVD0RIj2t976A+czLHr2nY454RwwXs6JU9Htc6mwqL6Dn/nEL3dpVf2jOhg==",
+        "dependencies": {
+          "Microsoft.Win32.SystemEvents": "6.0.0"
+        }
+      },
+      "System.IO.FileSystem.AccessControl": {
+        "type": "Transitive",
+        "resolved": "4.7.0",
+        "contentHash": "vMToiarpU81LR1/KZtnT7VDPvqAZfw9oOS5nY6pPP78nGYz3COLsQH3OfzbR+SjTgltd31R6KmKklz/zDpTmzw=="
+      },
       "System.Memory.Data": {
         "type": "Transitive",
         "resolved": "10.0.3",
@@ -314,8 +422,24 @@
       },
       "System.Security.Cryptography.ProtectedData": {
         "type": "Transitive",
-        "resolved": "4.5.0",
-        "contentHash": "wLBKzFnDCxP12VL9ANydSYhk59fC4cvOr9ypYQLPnAj48NQIhqnjdD2yhP8yEKyBJEjERWS9DisKL7rX5eU25Q=="
+        "resolved": "6.0.0",
+        "contentHash": "rp1gMNEZpvx9vP0JW0oHLxlf8oSiQgtno77Y4PLUBjSiDYoD77Y8uXHr1Ea5XG4/pIKhqAdxZ8v8OTUtqo9PeQ=="
+      },
+      "System.Security.Permissions": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "T/uuc7AklkDoxmcJ7LGkyX1CcSviZuLCa4jg3PekfJ7SU0niF0IVTXwUiNVP9DSpzou2PpxJ+eNY2IfDM90ZCg==",
+        "dependencies": {
+          "System.Windows.Extensions": "6.0.0"
+        }
+      },
+      "System.Windows.Extensions": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "IXoJOXIqc39AIe+CIR7koBtRGMiCt/LPM3lI+PELtDIy9XdyeSrwXFdWV9dzJ2Awl0paLWUaknLxFQ5HpHZUog==",
+        "dependencies": {
+          "System.Drawing.Common": "6.0.0"
+        }
       },
       "banderas.application": {
         "type": "Project",
@@ -332,6 +456,7 @@
         "dependencies": {
           "Banderas.Application": "[1.0.0, )",
           "Banderas.Domain": "[1.0.0, )",
+          "Microsoft.ApplicationInsights": "[2.*, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.1, )"
         }
       }

--- a/Banderas.Application/Services/BanderasService.cs
+++ b/Banderas.Application/Services/BanderasService.cs
@@ -4,6 +4,7 @@ using System.Text;
 using Banderas.Application.DTOs;
 using Banderas.Application.Evaluation;
 using Banderas.Application.Interfaces;
+using Banderas.Application.Telemetry;
 using Banderas.Application.Validation;
 using Banderas.Domain.Entities;
 using Banderas.Domain.Enums;
@@ -19,16 +20,19 @@ public sealed class BanderasService : IBanderasService
     private readonly IBanderasRepository _repository;
     private readonly FeatureEvaluator _evaluator;
     private readonly ILogger<BanderasService> _logger;
+    private readonly ITelemetryService _telemetryService;
 
     public BanderasService(
         IBanderasRepository repository,
         FeatureEvaluator evaluator,
-        ILogger<BanderasService> logger
+        ILogger<BanderasService> logger,
+        ITelemetryService telemetryService
     )
     {
         _repository = repository;
         _evaluator = evaluator;
         _logger = logger;
+        _telemetryService = telemetryService;
     }
 
     public async Task<FlagResponse> GetFlagAsync(
@@ -83,6 +87,12 @@ public sealed class BanderasService : IBanderasService
             );
 
             LogResult(result);
+            _telemetryService.TrackEvaluation(
+                flagName,
+                false,
+                RolloutStrategy.None,
+                sanitizedContext.Environment
+            );
             return false;
         }
 
@@ -97,6 +107,12 @@ public sealed class BanderasService : IBanderasService
         );
 
         LogResult(strategyResult);
+        _telemetryService.TrackEvaluation(
+            flagName,
+            isEnabled,
+            flag.StrategyType,
+            sanitizedContext.Environment
+        );
         return isEnabled;
     }
 

--- a/Banderas.Application/Telemetry/ITelemetryService.cs
+++ b/Banderas.Application/Telemetry/ITelemetryService.cs
@@ -1,0 +1,13 @@
+using Banderas.Domain.Enums;
+
+namespace Banderas.Application.Telemetry;
+
+public interface ITelemetryService
+{
+    void TrackEvaluation(
+        string flagName,
+        bool result,
+        RolloutStrategy strategy,
+        EnvironmentType environment
+    );
+}

--- a/Banderas.Infrastructure/Banderas.Infrastructure.csproj
+++ b/Banderas.Infrastructure/Banderas.Infrastructure.csproj
@@ -5,6 +5,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.*" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.5" />
     <PackageReference
       Include="Microsoft.Extensions.DependencyInjection.Abstractions"

--- a/Banderas.Infrastructure/DependencyInjection.cs
+++ b/Banderas.Infrastructure/DependencyInjection.cs
@@ -1,9 +1,12 @@
+using Banderas.Application.Telemetry;
 using Banderas.Domain.Interfaces;
 using Banderas.Infrastructure.Persistence;
 using Banderas.Infrastructure.Seeding;
+using Banderas.Infrastructure.Telemetry;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 namespace Banderas.Infrastructure;
 
@@ -11,7 +14,8 @@ public static class DependencyInjection
 {
     public static IServiceCollection AddInfrastructure(
         this IServiceCollection services,
-        IConfiguration configuration
+        IConfiguration configuration,
+        IHostEnvironment environment
     )
     {
         services.AddDbContext<BanderasDbContext>(options =>
@@ -20,6 +24,15 @@ public static class DependencyInjection
 
         services.AddScoped<IBanderasRepository, BanderasRepository>();
         services.AddScoped<DatabaseSeeder>();
+
+        if (environment.IsEnvironment("Testing"))
+        {
+            services.AddSingleton<ITelemetryService, NullTelemetryService>();
+        }
+        else
+        {
+            services.AddSingleton<ITelemetryService, ApplicationInsightsTelemetryService>();
+        }
 
         return services;
     }

--- a/Banderas.Infrastructure/Telemetry/ApplicationInsightsTelemetryService.cs
+++ b/Banderas.Infrastructure/Telemetry/ApplicationInsightsTelemetryService.cs
@@ -1,0 +1,33 @@
+using Banderas.Application.Telemetry;
+using Banderas.Domain.Enums;
+using Microsoft.ApplicationInsights;
+
+namespace Banderas.Infrastructure.Telemetry;
+
+public sealed class ApplicationInsightsTelemetryService : ITelemetryService
+{
+    private readonly TelemetryClient _telemetryClient;
+
+    public ApplicationInsightsTelemetryService(TelemetryClient telemetryClient)
+    {
+        _telemetryClient = telemetryClient;
+    }
+
+    public void TrackEvaluation(
+        string flagName,
+        bool result,
+        RolloutStrategy strategy,
+        EnvironmentType environment
+    )
+    {
+        var properties = new Dictionary<string, string>
+        {
+            ["FlagName"] = flagName,
+            ["Result"] = result ? "enabled" : "disabled",
+            ["Strategy"] = strategy.ToString(),
+            ["Environment"] = environment.ToString(),
+        };
+
+        _telemetryClient.TrackEvent("flag.evaluated", properties);
+    }
+}

--- a/Banderas.Infrastructure/Telemetry/NullTelemetryService.cs
+++ b/Banderas.Infrastructure/Telemetry/NullTelemetryService.cs
@@ -1,0 +1,14 @@
+using Banderas.Application.Telemetry;
+using Banderas.Domain.Enums;
+
+namespace Banderas.Infrastructure.Telemetry;
+
+public sealed class NullTelemetryService : ITelemetryService
+{
+    public void TrackEvaluation(
+        string flagName,
+        bool result,
+        RolloutStrategy strategy,
+        EnvironmentType environment
+    ) { }
+}

--- a/Banderas.Infrastructure/packages.lock.json
+++ b/Banderas.Infrastructure/packages.lock.json
@@ -2,6 +2,12 @@
   "version": 1,
   "dependencies": {
     "net10.0": {
+      "Microsoft.ApplicationInsights": {
+        "type": "Direct",
+        "requested": "[2.*, )",
+        "resolved": "2.23.0",
+        "contentHash": "nWArUZTdU7iqZLycLKWe0TDms48KKGE6pONH2terYNa8REXiqixrMOkf1sk5DHGMaUTqONU2YkS4SAXBhLStgw=="
+      },
       "Microsoft.EntityFrameworkCore.Design": {
         "type": "Direct",
         "requested": "[10.0.4, )",

--- a/Banderas.Tests.Integration/packages.lock.json
+++ b/Banderas.Tests.Integration/packages.lock.json
@@ -128,6 +128,149 @@
         "resolved": "12.1.1",
         "contentHash": "EPpkIe1yh1a0OXyC100oOA8WMbZvqUu5plwhvYcb7oSELfyUZzfxV48BLhvs3kKo4NwG7MGLNgy1RJiYtT8Dpw=="
       },
+      "Microsoft.ApplicationInsights": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "nWArUZTdU7iqZLycLKWe0TDms48KKGE6pONH2terYNa8REXiqixrMOkf1sk5DHGMaUTqONU2YkS4SAXBhLStgw=="
+      },
+      "Microsoft.ApplicationInsights.AspNetCore": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "we/RsIn0Mwf/4ZNGXZixJ0lVD3pqjx2yVeKfqJybgYY/Lib8nnf+8YGJp+ULN3kOk39I0pI/7ZnF9LFy6hS3lw==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.23.0",
+          "Microsoft.ApplicationInsights.DependencyCollector": "2.23.0",
+          "Microsoft.ApplicationInsights.EventCounterCollector": "2.23.0",
+          "Microsoft.ApplicationInsights.PerfCounterCollector": "2.23.0",
+          "Microsoft.ApplicationInsights.WindowsServer": "2.23.0",
+          "Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel": "2.23.0",
+          "Microsoft.AspNetCore.Hosting": "2.1.1",
+          "Microsoft.AspNetCore.Http": "2.1.22",
+          "Microsoft.Extensions.Configuration.Json": "3.1.0",
+          "Microsoft.Extensions.Logging.ApplicationInsights": "2.23.0"
+        }
+      },
+      "Microsoft.ApplicationInsights.DependencyCollector": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "9YRdl9SNbTxd4AafJckyoJLr5gJdnvqFivjo+PY0lQTPEncPB+z3ZABG4iDfxN9HI1aLqyRINr1/7de9Wg8ZuQ==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.23.0"
+        }
+      },
+      "Microsoft.ApplicationInsights.EventCounterCollector": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "gGt0JPw2dcSeIAIefyORJBdeMz8KgAFIktu8HV/NwkiGmLyw+YtifLm6B5gvGxO15AeMsGPbmvWEIvLfq88XPw==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.23.0"
+        }
+      },
+      "Microsoft.ApplicationInsights.PerfCounterCollector": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "q9ApjZfBS9O8m3aQM2oVjsGBmlE8BCFywT7UR+8aqdNuz7HpoIxw4jHy0XOBergiFX/olrJF4OyPkGxc3H5JHg==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.23.0",
+          "Microsoft.Extensions.Caching.Memory": "1.0.0",
+          "System.Diagnostics.PerformanceCounter": "6.0.0"
+        }
+      },
+      "Microsoft.ApplicationInsights.WindowsServer": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "2B8CGfnB/tribkQAqRBhMvJYJK5TkEPMG/BB0QrlxdwVGEufayNLMveXjkQCqld9arXd6wKR1ve2XmkA0+xXKQ==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.23.0",
+          "Microsoft.ApplicationInsights.DependencyCollector": "2.23.0",
+          "Microsoft.ApplicationInsights.PerfCounterCollector": "2.23.0",
+          "Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel": "2.23.0"
+        }
+      },
+      "Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "798Dudr4tkujslk1w+XcXOcCErmVsk+nhp+QCHLa3lcgi25vkAxBmzPUeQlRJVCNL/1f4x/YF+vQZ8RSuTXWCw==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.23.0",
+          "System.IO.FileSystem.AccessControl": "4.7.0"
+        }
+      },
+      "Microsoft.AspNetCore.Hosting": {
+        "type": "Transitive",
+        "resolved": "2.1.1",
+        "contentHash": "MqYc0DUxrhAPnb5b4HFspxsoJT+gJlLsliSxIgovf4BsbmpaXQId0/pDiVzLuEbmks2w1/lRfY8w0lQOuK1jQQ==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Hosting.Abstractions": "2.1.1",
+          "Microsoft.AspNetCore.Http": "2.1.1",
+          "Microsoft.AspNetCore.Http.Extensions": "2.1.1",
+          "Microsoft.Extensions.Configuration": "2.1.1",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "2.1.1",
+          "Microsoft.Extensions.Configuration.FileExtensions": "2.1.1",
+          "Microsoft.Extensions.DependencyInjection": "2.1.1",
+          "Microsoft.Extensions.FileProviders.Physical": "2.1.1",
+          "Microsoft.Extensions.Hosting.Abstractions": "2.1.1",
+          "Microsoft.Extensions.Logging": "2.1.1",
+          "Microsoft.Extensions.Options": "2.1.1"
+        }
+      },
+      "Microsoft.AspNetCore.Hosting.Abstractions": {
+        "type": "Transitive",
+        "resolved": "2.1.1",
+        "contentHash": "76cKcp2pWhvdV2TXTqMg/DyW7N6cDzTEhtL8vVWFShQN+Ylwv3eO/vUQr2BS3Hz4IZHEpL+FOo2T+MtymHDqDQ==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Hosting.Server.Abstractions": "2.1.1",
+          "Microsoft.AspNetCore.Http.Abstractions": "2.1.1",
+          "Microsoft.Extensions.Hosting.Abstractions": "2.1.1"
+        }
+      },
+      "Microsoft.AspNetCore.Hosting.Server.Abstractions": {
+        "type": "Transitive",
+        "resolved": "2.1.1",
+        "contentHash": "+vD7HJYzAXNq17t+NgRkpS38cxuAyOBu8ixruOiA3nWsybozolUdALWiZ5QFtGRzajSLPFA2YsbO3NPcqoUwcw==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Http.Features": "2.1.1",
+          "Microsoft.Extensions.Configuration.Abstractions": "2.1.1"
+        }
+      },
+      "Microsoft.AspNetCore.Http": {
+        "type": "Transitive",
+        "resolved": "2.1.22",
+        "contentHash": "+Blk++1JWqghbl8+3azQmKhiNZA5wAepL9dY2I6KVmu2Ri07MAcvAVC888qUvO7yd7xgRgZOMfihezKg14O/2A==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Http.Abstractions": "2.1.1",
+          "Microsoft.AspNetCore.WebUtilities": "2.1.1",
+          "Microsoft.Extensions.ObjectPool": "2.1.1",
+          "Microsoft.Extensions.Options": "2.1.1",
+          "Microsoft.Net.Http.Headers": "2.1.1"
+        }
+      },
+      "Microsoft.AspNetCore.Http.Abstractions": {
+        "type": "Transitive",
+        "resolved": "2.1.1",
+        "contentHash": "kQUEVOU4loc8CPSb2WoHFTESqwIa8Ik7ysCBfTwzHAd0moWovc9JQLmhDIHlYLjHbyexqZAlkq/FPRUZqokebw==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Http.Features": "2.1.1"
+        }
+      },
+      "Microsoft.AspNetCore.Http.Extensions": {
+        "type": "Transitive",
+        "resolved": "2.1.1",
+        "contentHash": "ncAgV+cqsWSqjLXFUTyObGh4Tr7ShYYs3uW8Q/YpRwZn7eLV7dux5Z6GLY+rsdzmIHiia3Q2NWbLULQi7aziHw==",
+        "dependencies": {
+          "Microsoft.AspNetCore.Http.Abstractions": "2.1.1",
+          "Microsoft.Extensions.FileProviders.Abstractions": "2.1.1",
+          "Microsoft.Net.Http.Headers": "2.1.1"
+        }
+      },
+      "Microsoft.AspNetCore.Http.Features": {
+        "type": "Transitive",
+        "resolved": "2.1.1",
+        "contentHash": "VklZ7hWgSvHBcDtwYYkdMdI/adlf7ebxTZ9kdzAhX+gUs5jSHE9mZlTamdgf9miSsxc1QjNazHXTDJdVPZKKTw==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "2.1.1"
+        }
+      },
       "Microsoft.AspNetCore.OpenApi": {
         "type": "Transitive",
         "resolved": "10.0.5",
@@ -140,6 +283,14 @@
         "type": "Transitive",
         "resolved": "10.0.5",
         "contentHash": "PJEdrZnnhvxIEXzDdvdZ38GvpdaiUfKkZ99kudS8riJwhowFb/Qh26Wjk9smrCWcYdMFQmpN5epGiL4o1s8LYA=="
+      },
+      "Microsoft.AspNetCore.WebUtilities": {
+        "type": "Transitive",
+        "resolved": "2.1.1",
+        "contentHash": "PGKIZt4+412Z/XPoSjvYu/QIbTxcAQuEFNoA1Pw8a9mgmO0ZhNBmfaNyhgXFf7Rq62kP0tT/2WXpxdcQhkFUPA==",
+        "dependencies": {
+          "Microsoft.Net.Http.Headers": "2.1.1"
+        }
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
@@ -400,6 +551,15 @@
           "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.5"
         }
       },
+      "Microsoft.Extensions.Logging.ApplicationInsights": {
+        "type": "Transitive",
+        "resolved": "2.23.0",
+        "contentHash": "JLEabPz445i1yRB0hKZVzJJE35QatRIzWlrMOiBQXr9kBJod0jkpkrBf94ln6kXu+jlEGohnXtuXacPPhybJDw==",
+        "dependencies": {
+          "Microsoft.ApplicationInsights": "2.23.0",
+          "Microsoft.Extensions.Logging": "2.1.1"
+        }
+      },
       "Microsoft.Extensions.Logging.Configuration": {
         "type": "Transitive",
         "resolved": "10.0.5",
@@ -461,6 +621,11 @@
           "Microsoft.Extensions.Primitives": "10.0.5"
         }
       },
+      "Microsoft.Extensions.ObjectPool": {
+        "type": "Transitive",
+        "resolved": "2.1.1",
+        "contentHash": "SErON45qh4ogDp6lr6UvVmFYW0FERihW+IQ+2JyFv1PUyWktcJytFaWH5zarufJvZwhci7Rf1IyGXr9pVEadTw=="
+      },
       "Microsoft.Extensions.Options": {
         "type": "Transitive",
         "resolved": "10.0.5",
@@ -509,6 +674,14 @@
         "resolved": "8.14.0",
         "contentHash": "iwbCpSjD3ehfTwBhtSNEtKPK0ICun6ov7Ibx6ISNA9bfwIyzI2Siwyi9eJFCJBwxowK9xcA1mj+jBWiigeqgcQ=="
       },
+      "Microsoft.Net.Http.Headers": {
+        "type": "Transitive",
+        "resolved": "2.1.1",
+        "contentHash": "lPNIphl8b2EuhOE9dMH6EZDmu7pS882O+HMi5BJNsigxHaWlBrYxZHFZgE18cyaPp6SSZcTkKkuzfjV/RRQKlA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "2.1.1"
+        }
+      },
       "Microsoft.OpenApi": {
         "type": "Transitive",
         "resolved": "2.0.0",
@@ -527,6 +700,11 @@
           "Microsoft.TestPlatform.ObjectModel": "18.4.0",
           "Newtonsoft.Json": "13.0.3"
         }
+      },
+      "Microsoft.Win32.SystemEvents": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "hqTM5628jSsQiv+HGpiq3WKBl2c8v1KZfby2J6Pr7pEPlK9waPdgEO6b8A/+/xn/yZ9ulv8HuqK71ONy2tg67A=="
       },
       "Newtonsoft.Json": {
         "type": "Transitive",
@@ -581,10 +759,40 @@
           "System.Memory.Data": "10.0.3"
         }
       },
+      "System.Configuration.ConfigurationManager": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "7T+m0kDSlIPTHIkPMIu6m6tV6qsMqJpvQWW2jIc2qi7sn40qxFo0q+7mEQAhMPXZHMKnWrnv47ntGlM/ejvw3g==",
+        "dependencies": {
+          "System.Security.Cryptography.ProtectedData": "6.0.0",
+          "System.Security.Permissions": "6.0.0"
+        }
+      },
       "System.Diagnostics.EventLog": {
         "type": "Transitive",
         "resolved": "10.0.5",
         "contentHash": "wugvy+pBVzjQEnRs9wMTWwoaeNFX3hsaHeVHFDIvJSWXp7wfmNWu3mxAwBIE6pyW+g6+rHa1Of5fTzb0QVqUTA=="
+      },
+      "System.Diagnostics.PerformanceCounter": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "gbeE5tNp/oB7O8kTTLh3wPPJCxpNOphXPTWVs1BsYuFOYapFijWuh0LYw1qnDo4gwDUYPXOmpTIhvtxisGsYOQ==",
+        "dependencies": {
+          "System.Configuration.ConfigurationManager": "6.0.0"
+        }
+      },
+      "System.Drawing.Common": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "NfuoKUiP2nUWwKZN6twGqXioIe1zVD0RIj2t976A+czLHr2nY454RwwXs6JU9Htc6mwqL6Dn/nEL3dpVf2jOhg==",
+        "dependencies": {
+          "Microsoft.Win32.SystemEvents": "6.0.0"
+        }
+      },
+      "System.IO.FileSystem.AccessControl": {
+        "type": "Transitive",
+        "resolved": "4.7.0",
+        "contentHash": "vMToiarpU81LR1/KZtnT7VDPvqAZfw9oOS5nY6pPP78nGYz3COLsQH3OfzbR+SjTgltd31R6KmKklz/zDpTmzw=="
       },
       "System.Memory.Data": {
         "type": "Transitive",
@@ -593,8 +801,24 @@
       },
       "System.Security.Cryptography.ProtectedData": {
         "type": "Transitive",
-        "resolved": "4.5.0",
-        "contentHash": "wLBKzFnDCxP12VL9ANydSYhk59fC4cvOr9ypYQLPnAj48NQIhqnjdD2yhP8yEKyBJEjERWS9DisKL7rX5eU25Q=="
+        "resolved": "6.0.0",
+        "contentHash": "rp1gMNEZpvx9vP0JW0oHLxlf8oSiQgtno77Y4PLUBjSiDYoD77Y8uXHr1Ea5XG4/pIKhqAdxZ8v8OTUtqo9PeQ=="
+      },
+      "System.Security.Permissions": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "T/uuc7AklkDoxmcJ7LGkyX1CcSviZuLCa4jg3PekfJ7SU0niF0IVTXwUiNVP9DSpzou2PpxJ+eNY2IfDM90ZCg==",
+        "dependencies": {
+          "System.Windows.Extensions": "6.0.0"
+        }
+      },
+      "System.Windows.Extensions": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "IXoJOXIqc39AIe+CIR7koBtRGMiCt/LPM3lI+PELtDIy9XdyeSrwXFdWV9dzJ2Awl0paLWUaknLxFQ5HpHZUog==",
+        "dependencies": {
+          "System.Drawing.Common": "6.0.0"
+        }
       },
       "Testcontainers": {
         "type": "Transitive",
@@ -655,6 +879,7 @@
           "Azure.Identity": "[1.*, )",
           "Banderas.Application": "[1.0.0, )",
           "Banderas.Infrastructure": "[1.0.0, )",
+          "Microsoft.ApplicationInsights.AspNetCore": "[2.*, )",
           "Microsoft.AspNetCore.OpenApi": "[10.0.5, )",
           "Scalar.AspNetCore": "[2.*, )"
         }
@@ -675,6 +900,7 @@
         "dependencies": {
           "Banderas.Application": "[1.0.0, )",
           "Banderas.Domain": "[1.0.0, )",
+          "Microsoft.ApplicationInsights": "[2.*, )",
           "Microsoft.Extensions.Configuration.Abstractions": "[10.0.5, )",
           "Microsoft.Extensions.DependencyInjection.Abstractions": "[10.0.5, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.1, )"

--- a/Banderas.Tests/Services/BanderasServiceLoggingTests.cs
+++ b/Banderas.Tests/Services/BanderasServiceLoggingTests.cs
@@ -1,6 +1,7 @@
 using Banderas.Application.Evaluation;
 using Banderas.Application.Services;
 using Banderas.Application.Strategies;
+using Banderas.Application.Telemetry;
 using Banderas.Domain.Entities;
 using Banderas.Domain.Enums;
 using Banderas.Domain.Exceptions;
@@ -24,7 +25,7 @@ public sealed class BanderasServiceLoggingTests
         _repo = new TestBanderasRepository();
         _evaluator = new FeatureEvaluator(new IRolloutStrategy[] { new NoneStrategy() });
         _fakeLogger = new FakeLogger<BanderasService>();
-        _service = new BanderasService(_repo, _evaluator, _fakeLogger);
+        _service = new BanderasService(_repo, _evaluator, _fakeLogger, new NullTelemetryService());
     }
 
     [Fact]
@@ -117,6 +118,16 @@ public sealed class BanderasServiceLoggingTests
 
         Assert.Equal(LogLevel.Warning, record.Level);
         Assert.Contains("missing-flag", record.Message);
+    }
+
+    private sealed class NullTelemetryService : ITelemetryService
+    {
+        public void TrackEvaluation(
+            string flagName,
+            bool result,
+            RolloutStrategy strategy,
+            EnvironmentType environment
+        ) { }
     }
 
     private sealed class TestBanderasRepository : IBanderasRepository

--- a/Docs/Decisions/application-insights-PR#51/implementation-notes.md
+++ b/Docs/Decisions/application-insights-PR#51/implementation-notes.md
@@ -1,0 +1,111 @@
+# application-insights — Implementation Notes
+
+**Session date:** 2026-04-19
+**Branch:** `feature/application-insights`
+**Spec reference:** `Docs/Decisions/application-insights-PR#51/spec.md`
+**Build status:** Passed — 0 warnings, 0 errors
+**Tests:** 113/113 passing
+**PR:** #51
+
+---
+
+## Table of Contents
+
+- [What Was Built](#what-was-built)
+- [Files Changed](#files-changed)
+- [Key Decisions](#key-decisions)
+- [NuGet Packages Added](#nuget-packages-added)
+- [Unit Test Fixture Fix](#unit-test-fixture-fix)
+- [Manual Step Required](#manual-step-required)
+
+---
+
+## What Was Built
+
+Application Insights telemetry wired into Banderas across two concerns:
+
+1. **Auto-captured telemetry** — every HTTP request, unhandled exception, and EF Core/Postgres dependency is recorded by the SDK with zero manual instrumentation, enabled via `AddApplicationInsightsTelemetry()` in `Program.cs`.
+2. **Custom evaluation events** — every flag evaluation emits a named `flag.evaluated` custom event with four structured dimensions (`FlagName`, `Result`, `Strategy`, `Environment`) queryable in KQL.
+
+---
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `Banderas.Application/Telemetry/ITelemetryService.cs` | New — interface in Application layer |
+| `Banderas.Infrastructure/Telemetry/ApplicationInsightsTelemetryService.cs` | New — `TelemetryClient`-backed implementation |
+| `Banderas.Infrastructure/Telemetry/NullTelemetryService.cs` | New — no-op for Testing environment |
+| `Banderas.Application/Services/BanderasService.cs` | `ITelemetryService` injected; `TrackEvaluation` called in both evaluation branches |
+| `Banderas.Infrastructure/DependencyInjection.cs` | Added `IHostEnvironment` param; conditional registration of `ITelemetryService` |
+| `Banderas.Api/Program.cs` | `AddApplicationInsightsTelemetry()` added before `Build()`; `builder.Environment` passed to `AddInfrastructure` |
+| `Banderas.Api/appsettings.json` | `ApplicationInsights.ConnectionString` placeholder added |
+| `Banderas.Infrastructure/Banderas.Infrastructure.csproj` | `Microsoft.ApplicationInsights` package added |
+| `Banderas.Api/Banderas.Api.csproj` | `Microsoft.ApplicationInsights.AspNetCore` package added |
+| `Banderas.Tests/Services/BanderasServiceLoggingTests.cs` | Local `NullTelemetryService` stub added to satisfy updated constructor |
+
+---
+
+## Key Decisions
+
+### Interface in Application, implementation in Infrastructure
+
+`ITelemetryService` lives in `Banderas.Application.Telemetry`. `BanderasService` depends only on the interface — it has no knowledge of the Application Insights SDK. This is the same Dependency Inversion pattern used for `IBanderasRepository`. Swapping Application Insights for OpenTelemetry requires zero changes to business logic.
+
+### Custom Event over Trace
+
+Flag evaluations are business facts with queryable dimensions. `TelemetryClient.TrackEvent("flag.evaluated", properties)` emits a Custom Event, enabling KQL queries like:
+
+```kusto
+customEvents
+| where name == "flag.evaluated"
+| where customDimensions.FlagName == "dark-mode"
+| summarize count() by tostring(customDimensions.Result), bin(timestamp, 1h)
+```
+
+Traces cannot be aggregated this way. The existing `ILogger` calls are unchanged and continue to flow as Traces — the custom event is additive.
+
+### `TrackEvaluation` called in `BanderasService`, not `FeatureEvaluator`
+
+`FeatureEvaluator` is a pure function — no side effects, no dependencies. The call site is `BanderasService.IsEnabledAsync()` after `LogResult()` in both the `FlagDisabled` and `StrategyEvaluated` branches. The `FlagNotFoundException` path does not emit telemetry — exceptions are auto-captured by the SDK middleware.
+
+### Singleton lifetime for `ITelemetryService`
+
+`TelemetryClient` is thread-safe and maintains an internal buffer that flushes to Azure on a background timer. It must be a singleton. `ApplicationInsightsTelemetryService` wraps it with no mutable state, so Singleton is correct for both.
+
+### `NullTelemetryService` for Testing environment
+
+Registered when `IHostEnvironment.IsEnvironment("Testing")` is true. Integration tests already use `UseEnvironment("Testing")` from PR #39, so they resolve the no-op automatically. This is the Null Object Pattern — consuming code never checks whether telemetry is live or suppressed.
+
+### Connection string from Key Vault
+
+`appsettings.json` carries an empty placeholder. The real value is stored as `ApplicationInsights--ConnectionString` in `kv-banderas-dev`. The Key Vault provider (PR #50) loads it into `IConfiguration` at startup. `AddApplicationInsightsTelemetry()` reads `IConfiguration["ApplicationInsights:ConnectionString"]` automatically — no bridge code required. An empty string disables telemetry silently; no startup exception is thrown.
+
+---
+
+## NuGet Packages Added
+
+| Package | Project | Reason |
+|---|---|---|
+| `Microsoft.ApplicationInsights` `2.*` | `Banderas.Infrastructure` | Provides `TelemetryClient` used in `ApplicationInsightsTelemetryService` |
+| `Microsoft.ApplicationInsights.AspNetCore` `2.*` | `Banderas.Api` | Provides `AddApplicationInsightsTelemetry()` extension and ASP.NET Core middleware for auto-capture |
+
+---
+
+## Unit Test Fixture Fix
+
+`BanderasServiceLoggingTests` constructs `BanderasService` directly and does not reference `Banderas.Infrastructure`. A private `NullTelemetryService` stub was added to the test class to satisfy the updated constructor — no new project reference or mocking library required.
+
+---
+
+## Manual Step Required
+
+Add the Application Insights connection string to Key Vault before deploying:
+
+```
+Secret name:  ApplicationInsights--ConnectionString
+Value:        <connection string from Azure Portal → Application Insights resource → Overview>
+Key Vault:    kv-banderas-dev
+```
+
+The application starts and runs correctly without this secret — telemetry is silently disabled when the connection string is empty.

--- a/Docs/Decisions/application-insights-PR#51/spec.md
+++ b/Docs/Decisions/application-insights-PR#51/spec.md
@@ -1,0 +1,664 @@
+# Application Insights Integration — Spec
+
+**Document:** `Docs/Decisions/application-insights-pr51/spec.md`
+**Branch:** `feature/application-insights`
+**Phase:** 1.5 — Azure Foundation + AI Integration
+**PR:** #51
+**Status:** Ready for Implementation
+**Author:** Jose / Claude Architect Session
+**Date:** 2026-04-19
+
+---
+
+## Table of Contents
+
+- [User Story](#user-story)
+- [Background & Goals](#background--goals)
+- [Non-Goals](#non-goals)
+- [Design Decisions](#design-decisions)
+  - [DD-1: ITelemetryService — Interface in Application, Implementation in Infrastructure](#dd-1-itelemetryservice--interface-in-application-implementation-in-infrastructure)
+  - [DD-2: Custom Event over Trace for Evaluation Telemetry](#dd-2-custom-event-over-trace-for-evaluation-telemetry)
+  - [DD-3: Connection String from Key Vault, Not Code](#dd-3-connection-string-from-key-vault-not-code)
+  - [DD-4: Auto-Capture for Request, Exception, and Dependency Telemetry](#dd-4-auto-capture-for-request-exception-and-dependency-telemetry)
+  - [DD-5: No ITelemetryService Call in FeatureEvaluator](#dd-5-no-itelemetryservice-call-in-featureevaluator)
+- [Scope](#scope)
+- [File Layout](#file-layout)
+- [New Files](#new-files)
+  - [ITelemetryService.cs](#itelemetryservicecs)
+  - [ApplicationInsightsTelemetryService.cs](#applicationinsightstelemetryservicecs)
+- [Modified Files](#modified-files)
+  - [BanderasService.cs](#banderasservicecs)
+  - [Infrastructure/DependencyInjection.cs](#infrastructuredependencyinjectioncs)
+  - [Program.cs](#programcs)
+  - [appsettings.json](#appsettingsjson)
+  - [appsettings.Development.json](#appsettingsdevelopmentjson)
+- [Acceptance Criteria](#acceptance-criteria)
+  - [AC-1: ITelemetryService Interface](#ac-1-itelemetryservice-interface)
+  - [AC-2: ApplicationInsightsTelemetryService Implementation](#ac-2-applicationinsightstelemetryservice-implementation)
+  - [AC-3: BanderasService Calls ITelemetryService](#ac-3-banderasservice-calls-itelemetryservice)
+  - [AC-4: Auto-Capture Wired in Program.cs](#ac-4-auto-capture-wired-in-programcs)
+  - [AC-5: Connection String Configuration](#ac-5-connection-string-configuration)
+  - [AC-6: NullTelemetryService for Testing](#ac-6-nulltelemetryservice-for-testing)
+  - [AC-7: Build and Tests Pass](#ac-7-build-and-tests-pass)
+- [Learning Opportunities](#learning-opportunities)
+- [Known Constraints](#known-constraints)
+- [Out of Scope](#out-of-scope)
+- [Definition of Done](#definition-of-done)
+
+---
+
+## User Story
+
+> As an engineer operating Banderas in Azure, I want structured telemetry flowing
+> into Application Insights — including request traces, exceptions, Postgres query
+> timings, and a custom `flag.evaluated` event per evaluation — so that I can
+> monitor API health, debug failures, and understand which flags are evaluated most
+> frequently, all from the Azure portal without reading raw logs.
+
+---
+
+## Background & Goals
+
+PR #48 introduced structured evaluation decision logging via `ILogger<BanderasService>`.
+Log output flows to the console — visible locally, gone on container restart, and
+unsearchable across time.
+
+Application Insights is an Azure-native telemetry sink that persists telemetry,
+makes it queryable via Kusto (KQL), and provides dashboards for request health,
+exception tracking, and dependency performance.
+
+This PR wires Application Insights into Banderas with two goals:
+
+1. **Auto-captured telemetry** — every HTTP request, unhandled exception, and
+   outbound Postgres query is recorded with zero manual instrumentation.
+2. **Custom evaluation events** — every flag evaluation emits a named
+   `flag.evaluated` event with structured properties (flag name, result, strategy,
+   environment) that can be queried by flag name over time.
+
+---
+
+## Non-Goals
+
+- Moving the Azure OpenAI connection string to Key Vault — Phase 1.5 PR #52
+- Kusto (KQL) query setup or Application Insights dashboard configuration
+- Distributed tracing across multiple services (single-service for now)
+- Any changes to existing `ILogger` usage — both coexist
+- Serilog or any third-party logging library
+- UI or API surface changes
+
+---
+
+## Design Decisions
+
+---
+
+### DD-1: ITelemetryService — Interface in Application, Implementation in Infrastructure
+
+`TelemetryClient` lives in `Microsoft.ApplicationInsights` — a third-party SDK
+package. Injecting it directly into `BanderasService` (Application layer) would
+introduce an external infrastructure dependency into the core of the system,
+violating the Clean Architecture dependency rule: Application and Domain must not
+reference external packages.
+
+**Solution:** Define `ITelemetryService` in the Application layer. Implement it
+in Infrastructure using `TelemetryClient`. `BanderasService` depends only on the
+interface — it has no knowledge of Application Insights.
+
+This is the same pattern used for `IBanderasRepository` and EF Core. The
+Application layer defines what it needs. Infrastructure delivers it.
+
+**Why it matters for interviews:** This is the Dependency Inversion Principle
+applied to telemetry. Swapping Application Insights for OpenTelemetry or a stub
+requires zero changes to business logic.
+
+---
+
+### DD-2: Custom Event over Trace for Evaluation Telemetry
+
+Application Insights has two relevant telemetry types for evaluation outcomes:
+
+- **Trace** — a timestamped log line with a severity level. Passive narration.
+  Queryable as free text in Application Insights Logs.
+- **Custom Event** — a named business occurrence with structured key-value
+  properties. Queryable by event name and property value in Application Insights.
+
+Evaluation outcomes are business facts — "flag X was evaluated for user Y and
+returned false using the Percentage strategy." They have specific, queryable
+dimensions. Sending them as Custom Events means you can write:
+
+```kusto
+customEvents
+| where name == "flag.evaluated"
+| where customDimensions.FlagName == "dark-mode"
+| summarize count() by tostring(customDimensions.Result), bin(timestamp, 1h)
+```
+
+Traces cannot be aggregated this way. Custom Events are the correct type.
+
+The existing `ILogger` Trace telemetry is not removed — both coexist. `ILogger`
+output flows into Application Insights as Traces automatically once the SDK is
+wired. The custom event is additive, not a replacement.
+
+---
+
+### DD-3: Connection String from Key Vault, Not Code
+
+The Application Insights connection string must not be committed to source code
+or `appsettings.json`. It is added to `kv-banderas-dev` as:
+
+```
+Secret name:  ApplicationInsights--ConnectionString
+```
+
+The Application Insights SDK reads from `IConfiguration["ApplicationInsights:ConnectionString"]`
+automatically when `AddApplicationInsightsTelemetry()` is called. Key Vault
+loads the secret into `IConfiguration` at startup via the provider wired in
+PR #50. No additional code is required to bridge Key Vault → SDK.
+
+`appsettings.json` carries an empty placeholder:
+```json
+"ApplicationInsights": {
+  "ConnectionString": ""
+}
+```
+
+`appsettings.Development.json` carries the actual dev connection string for
+local development when Key Vault is not available (optional — see Known Constraints).
+
+---
+
+### DD-4: Auto-Capture for Request, Exception, and Dependency Telemetry
+
+`AddApplicationInsightsTelemetry()` in `Program.cs` automatically captures:
+
+| Telemetry Type | What it records | Banderas example |
+|---|---|---|
+| Request | Every HTTP call — method, URL, status code, duration | `GET /api/flags/dark-mode → 200, 38ms` |
+| Exception | Unhandled exceptions flowing through middleware | `FlagNotFoundException` on evaluate |
+| Dependency | Outbound calls — Postgres queries via EF Core | `SELECT * FROM "Flags" → 12ms` |
+
+No manual instrumentation is required for these three. They are free from the SDK.
+
+---
+
+### DD-5: No ITelemetryService Call in FeatureEvaluator
+
+`FeatureEvaluator` is a pure function. It takes a `Flag` and a
+`FeatureEvaluationContext` and returns a `bool`. It has no side effects and no
+dependencies beyond its strategy registry. This design makes it fast, testable,
+and easy to reason about.
+
+`ITelemetryService.TrackEvaluation()` is called in `BanderasService.IsEnabledAsync()`
+— after the evaluation result is known — not inside `FeatureEvaluator`. The
+imperative shell (`BanderasService`) owns all side effects. The pure core
+(`FeatureEvaluator`) remains untouched.
+
+---
+
+## Scope
+
+| # | What | Layer | File(s) |
+|---|---|---|---|
+| 1 | `ITelemetryService` interface | Application | `Application/Telemetry/ITelemetryService.cs` |
+| 2 | `ApplicationInsightsTelemetryService` | Infrastructure | `Infrastructure/Telemetry/ApplicationInsightsTelemetryService.cs` |
+| 3 | `NullTelemetryService` (test double) | Infrastructure | `Infrastructure/Telemetry/NullTelemetryService.cs` |
+| 4 | `BanderasService` — call `ITelemetryService` | Application | `Application/Services/BanderasService.cs` |
+| 5 | Wire `AddApplicationInsightsTelemetry()` | Api | `Api/Program.cs` |
+| 6 | Register `ITelemetryService` in DI | Infrastructure | `Infrastructure/DependencyInjection.cs` |
+| 7 | Config placeholders | Api | `appsettings.json`, `appsettings.Development.json` |
+
+---
+
+## File Layout
+
+```
+Banderas.Application/
+  Telemetry/
+    ITelemetryService.cs                    ← NEW
+
+Banderas.Infrastructure/
+  Telemetry/
+    ApplicationInsightsTelemetryService.cs  ← NEW
+    NullTelemetryService.cs                 ← NEW
+
+Banderas.Api/
+  Program.cs                                ← MODIFIED
+  appsettings.json                          ← MODIFIED
+  appsettings.Development.json              ← MODIFIED (optional — see Known Constraints)
+
+Banderas.Application/
+  Services/
+    BanderasService.cs                      ← MODIFIED
+
+Banderas.Infrastructure/
+  DependencyInjection.cs                    ← MODIFIED
+```
+
+---
+
+## New Files
+
+---
+
+### ITelemetryService.cs
+
+**Location:** `Banderas.Application/Telemetry/ITelemetryService.cs`
+
+```csharp
+using Banderas.Domain.Enums;
+
+namespace Banderas.Application.Telemetry;
+
+/// <summary>
+/// Abstraction for emitting business telemetry events.
+/// Implemented in Infrastructure — Application has no reference to any telemetry SDK.
+/// </summary>
+public interface ITelemetryService
+{
+    /// <summary>
+    /// Tracks a completed flag evaluation as a named business event.
+    /// Called by BanderasService after every evaluation outcome is known.
+    /// </summary>
+    void TrackEvaluation(
+        string flagName,
+        bool result,
+        RolloutStrategy strategy,
+        EnvironmentType environment
+    );
+}
+```
+
+**Design note:** `TrackEvaluation` is void and synchronous. Telemetry emission is
+a fire-and-forget concern — the evaluation response must not be delayed waiting
+for a telemetry flush. The Application Insights SDK buffers events internally and
+flushes on a background timer.
+
+---
+
+### ApplicationInsightsTelemetryService.cs
+
+**Location:** `Banderas.Infrastructure/Telemetry/ApplicationInsightsTelemetryService.cs`
+
+```csharp
+using Banderas.Application.Telemetry;
+using Banderas.Domain.Enums;
+using Microsoft.ApplicationInsights;
+
+namespace Banderas.Infrastructure.Telemetry;
+
+/// <summary>
+/// Application Insights implementation of ITelemetryService.
+/// Emits a "flag.evaluated" custom event with structured dimensions.
+/// </summary>
+public sealed class ApplicationInsightsTelemetryService : ITelemetryService
+{
+    private readonly TelemetryClient _telemetryClient;
+
+    public ApplicationInsightsTelemetryService(TelemetryClient telemetryClient)
+    {
+        _telemetryClient = telemetryClient;
+    }
+
+    public void TrackEvaluation(
+        string flagName,
+        bool result,
+        RolloutStrategy strategy,
+        EnvironmentType environment)
+    {
+        var properties = new Dictionary<string, string>
+        {
+            ["FlagName"]    = flagName,
+            ["Result"]      = result ? "enabled" : "disabled",
+            ["Strategy"]    = strategy.ToString(),
+            ["Environment"] = environment.ToString(),
+        };
+
+        _telemetryClient.TrackEvent("flag.evaluated", properties);
+    }
+}
+```
+
+**Custom event name:** `flag.evaluated` — lowercase with dot separator is the
+convention for custom event names in Application Insights. Queryable in KQL as
+`customEvents | where name == "flag.evaluated"`.
+
+---
+
+### NullTelemetryService.cs
+
+**Location:** `Banderas.Infrastructure/Telemetry/NullTelemetryService.cs`
+
+```csharp
+using Banderas.Application.Telemetry;
+using Banderas.Domain.Enums;
+
+namespace Banderas.Infrastructure.Telemetry;
+
+/// <summary>
+/// No-op implementation of ITelemetryService.
+/// Registered in the DI container when the environment is "Testing"
+/// so integration tests do not require an Application Insights connection string.
+/// </summary>
+public sealed class NullTelemetryService : ITelemetryService
+{
+    public void TrackEvaluation(
+        string flagName,
+        bool result,
+        RolloutStrategy strategy,
+        EnvironmentType environment)
+    {
+        // Intentionally empty — telemetry is suppressed in test environments.
+    }
+}
+```
+
+---
+
+## Modified Files
+
+---
+
+### BanderasService.cs
+
+**Location:** `Banderas.Application/Services/BanderasService.cs`
+
+**Changes required:**
+
+1. Add `ITelemetryService` constructor parameter and `_telemetryService` field.
+2. After `LogResult(result)` in `IsEnabledAsync`, call `_telemetryService.TrackEvaluation(...)`.
+3. `TrackEvaluation` must not be called on the `FlagNotFoundException` path — telemetry
+   tracks evaluation outcomes, not not-found errors. Exceptions are auto-captured by
+   Application Insights middleware.
+
+**Constructor — updated:**
+
+```csharp
+private readonly IBanderasRepository _repository;
+private readonly FeatureEvaluator _evaluator;
+private readonly ILogger<BanderasService> _logger;
+private readonly ITelemetryService _telemetryService;
+
+public BanderasService(
+    IBanderasRepository repository,
+    FeatureEvaluator evaluator,
+    ILogger<BanderasService> logger,
+    ITelemetryService telemetryService)
+{
+    _repository = repository;
+    _evaluator = evaluator;
+    _logger = logger;
+    _telemetryService = telemetryService;
+}
+```
+
+**IsEnabledAsync — evaluation paths updated:**
+
+After the `LogResult(result)` call in the `FlagDisabled` branch:
+```csharp
+LogResult(result);
+_telemetryService.TrackEvaluation(flagName, false, RolloutStrategy.None, sanitizedContext.Environment);
+return false;
+```
+
+After the `LogResult(strategyResult)` call in the `StrategyEvaluated` branch:
+```csharp
+LogResult(strategyResult);
+_telemetryService.TrackEvaluation(flagName, isEnabled, flag.StrategyType, sanitizedContext.Environment);
+return isEnabled;
+```
+
+**Important:** `TrackEvaluation` is called after `LogResult` in both branches.
+Telemetry emission order must not affect the return value.
+
+---
+
+### Infrastructure/DependencyInjection.cs
+
+**Location:** `Banderas.Infrastructure/DependencyInjection.cs`
+
+Register `ITelemetryService` conditionally based on environment:
+
+```csharp
+public static IServiceCollection AddInfrastructure(
+    this IServiceCollection services,
+    IConfiguration configuration,
+    IHostEnvironment environment)
+{
+    // ... existing EF Core registration ...
+
+    if (environment.IsEnvironment("Testing"))
+    {
+        services.AddSingleton<ITelemetryService, NullTelemetryService>();
+    }
+    else
+    {
+        services.AddSingleton<ITelemetryService, ApplicationInsightsTelemetryService>();
+    }
+
+    return services;
+}
+```
+
+**Note:** `AddInfrastructure` must accept `IHostEnvironment` as a parameter if
+it does not already. Update the call site in `Program.cs` accordingly.
+
+**Lifetime:** `Singleton` — `TelemetryClient` is thread-safe and designed to be
+a singleton. `ApplicationInsightsTelemetryService` wraps it and carries no
+mutable state, so Singleton is correct.
+
+---
+
+### Program.cs
+
+**Location:** `Banderas.Api/Program.cs`
+
+Add Application Insights telemetry **before** `builder.Build()`:
+
+```csharp
+builder.Services.AddApplicationInsightsTelemetry();
+```
+
+This single call enables all auto-captured telemetry (requests, exceptions,
+dependencies). The SDK reads `ApplicationInsights:ConnectionString` from
+`IConfiguration` automatically — no manual configuration object required.
+
+`AddApplicationInsightsTelemetry()` must be called before `builder.Build()`.
+Order relative to other service registrations does not matter.
+
+---
+
+### appsettings.json
+
+Add the Application Insights placeholder section:
+
+```json
+{
+  "Azure": {
+    "KeyVaultUri": ""
+  },
+  "ApplicationInsights": {
+    "ConnectionString": ""
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": ""
+  }
+}
+```
+
+The empty string is the correct placeholder — the SDK treats an empty connection
+string as "telemetry disabled" rather than throwing at startup.
+
+---
+
+### appsettings.Development.json
+
+Add the dev connection string **only if** a dev Application Insights resource
+exists. If one does not exist, omit this entry and telemetry will be silently
+disabled in local development. This is acceptable — the service runs correctly
+without telemetry.
+
+```json
+{
+  "ApplicationInsights": {
+    "ConnectionString": "InstrumentationKey=<dev-key>;..."
+  }
+}
+```
+
+> **Note:** If a dev Application Insights resource does not exist, leave this
+> section out of `appsettings.Development.json`. Do not commit a real production
+> connection string here.
+
+---
+
+## Acceptance Criteria
+
+---
+
+### AC-1: ITelemetryService Interface
+
+- [ ] File at `Banderas.Application/Telemetry/ITelemetryService.cs`
+- [ ] Namespace: `Banderas.Application.Telemetry`
+- [ ] Single method: `void TrackEvaluation(string flagName, bool result, RolloutStrategy strategy, EnvironmentType environment)`
+- [ ] No reference to `Microsoft.ApplicationInsights` or any infrastructure package
+
+---
+
+### AC-2: ApplicationInsightsTelemetryService Implementation
+
+- [ ] File at `Banderas.Infrastructure/Telemetry/ApplicationInsightsTelemetryService.cs`
+- [ ] Namespace: `Banderas.Infrastructure.Telemetry`
+- [ ] Implements `ITelemetryService`
+- [ ] Injects `TelemetryClient` via constructor
+- [ ] Calls `_telemetryClient.TrackEvent("flag.evaluated", properties)`
+- [ ] Properties dictionary contains: `FlagName`, `Result` (`"enabled"` or `"disabled"`), `Strategy`, `Environment`
+- [ ] `Result` is a string (`"enabled"` / `"disabled"`), not a bool — Application Insights custom dimensions are strings
+
+---
+
+### AC-3: BanderasService Calls ITelemetryService
+
+- [ ] `ITelemetryService` injected via constructor
+- [ ] `_telemetryService.TrackEvaluation(...)` called in the `FlagDisabled` path
+- [ ] `_telemetryService.TrackEvaluation(...)` called in the `StrategyEvaluated` path
+- [ ] `TrackEvaluation` is NOT called on the `FlagNotFoundException` path
+- [ ] `TrackEvaluation` is called after `LogResult` in both branches
+- [ ] `FeatureEvaluator.cs` is unchanged — no `ITelemetryService` reference
+
+---
+
+### AC-4: Auto-Capture Wired in Program.cs
+
+- [ ] `builder.Services.AddApplicationInsightsTelemetry()` present in `Program.cs`
+- [ ] Called before `builder.Build()`
+- [ ] No `TelemetryConfiguration` or `ApplicationInsightsServiceOptions` manual
+      configuration — defaults are sufficient for this phase
+
+---
+
+### AC-5: Connection String Configuration
+
+- [ ] `appsettings.json` — `"ApplicationInsights": { "ConnectionString": "" }` placeholder present
+- [ ] Secret `ApplicationInsights--ConnectionString` added to `kv-banderas-dev`
+      (manual Azure Portal step — documented in PR description, not code)
+- [ ] Key Vault loads the value into `IConfiguration["ApplicationInsights:ConnectionString"]`
+      at startup via the provider wired in PR #50
+- [ ] Application starts successfully when connection string is empty (local dev
+      without Key Vault access) — SDK disables telemetry silently, no exception thrown
+
+---
+
+### AC-6: NullTelemetryService for Testing
+
+- [ ] File at `Banderas.Infrastructure/Telemetry/NullTelemetryService.cs`
+- [ ] Implements `ITelemetryService`
+- [ ] `TrackEvaluation` body is empty (no-op)
+- [ ] `NullTelemetryService` registered when `IHostEnvironment.IsEnvironment("Testing")` is true
+- [ ] `ApplicationInsightsTelemetryService` registered for all other environments
+- [ ] `BanderasApiFactory.cs` — no changes required; `UseEnvironment("Testing")` from
+      PR #39 already ensures `NullTelemetryService` is resolved in integration tests
+
+---
+
+### AC-7: Build and Tests Pass
+
+- [ ] `dotnet build Banderas.sln` → 0 errors, 0 warnings
+- [ ] `dotnet test --filter "Category=Unit"` → all passing (count unchanged from PR #50 baseline)
+- [ ] `dotnet test --filter "Category=Integration"` → 113/113 passing
+- [ ] `dotnet csharpier check .` → 0 violations
+- [ ] Application starts locally with `docker compose up` — no startup exception
+      (telemetry disabled gracefully when connection string is empty)
+
+---
+
+## Learning Opportunities
+
+**💡 TelemetryClient is a Singleton by design**
+The Application Insights `TelemetryClient` maintains an internal buffer of telemetry
+events and flushes them to Azure on a background timer (default: 30 seconds). It is
+designed to be shared across the entire application lifetime — one instance per process.
+Registering it as anything other than Singleton would create multiple buffers, leading
+to event loss and unpredictable flush behavior.
+
+**💡 The Null Object Pattern**
+`NullTelemetryService` is an implementation of the Null Object Pattern — a class that
+satisfies an interface contract by doing nothing. It eliminates the need for null checks
+(`if (_telemetryService != null)`) throughout `BanderasService`. The consuming code
+never needs to know whether telemetry is real or suppressed. This is the same reason
+`ILogger<T>` uses `NullLogger<T>` in tests rather than passing `null`.
+
+**💡 IConfiguration as an abstraction layer**
+`AddApplicationInsightsTelemetry()` reads from `IConfiguration["ApplicationInsights:ConnectionString"]`
+— not from a hardcoded key. The SDK does not care whether that value came from
+`appsettings.json`, environment variables, or Key Vault. This is the Dependency
+Inversion Principle applied to configuration: consumers depend on the abstraction
+(`IConfiguration`), not the source.
+
+**💡 Fire-and-forget telemetry**
+`TrackEvaluation` is synchronous and void. The SDK buffers the event internally —
+your code does not wait for a network call to Azure. This is intentional: telemetry
+must never add latency to the hot path. The tradeoff is that events may be lost if
+the process crashes before the next flush. For feature flag telemetry, this is an
+acceptable tradeoff.
+
+---
+
+## Known Constraints
+
+| Constraint | Detail | Tracked For |
+|---|---|---|
+| Dev Application Insights resource may not exist | If no dev resource exists, local telemetry is silently disabled. No exception. | Acceptable |
+| Managed Identity not yet assigned | Local dev uses Key Vault via `az login`. Production Managed Identity is Phase 8. | Phase 8 |
+| No KQL queries or dashboard setup | Out of scope for this PR. | Post-Phase 1.5 |
+| TelemetryClient flush on shutdown | Default flush timeout is 5 seconds. Events buffered at shutdown time may be lost. | Phase 8 production hardening |
+
+---
+
+## Out of Scope
+
+- Kusto (KQL) queries or Application Insights workbooks
+- Distributed tracing across multiple services
+- Serilog or structured logging library changes
+- Any changes to existing `ILogger` calls in `BanderasService`
+- Moving any other secrets to Key Vault (PR #52 scope)
+- `GET /api/flags/{name}/trace` evaluation trace endpoint (Phase 4)
+
+---
+
+## Definition of Done
+
+- [ ] `ITelemetryService` defined in Application layer with no infrastructure references
+- [ ] `ApplicationInsightsTelemetryService` implemented in Infrastructure
+- [ ] `NullTelemetryService` implemented and registered for Testing environment
+- [ ] `BanderasService` calls `TrackEvaluation` on both evaluation outcome paths
+- [ ] `AddApplicationInsightsTelemetry()` wired in `Program.cs`
+- [ ] `ApplicationInsights--ConnectionString` secret added to `kv-banderas-dev`
+- [ ] `appsettings.json` placeholder present
+- [ ] 0 build errors, 0 warnings
+- [ ] 113/113 tests passing
+- [ ] CSharpier clean
+- [ ] Application starts locally without exception when connection string is empty
+
+---
+
+*Banderas | feature/application-insights | Phase 1.5 — Azure Foundation | v1.0*


### PR DESCRIPTION
## Summary

- Wires `AddApplicationInsightsTelemetry()` for auto-captured request, exception, and Postgres dependency telemetry
- Adds `ITelemetryService` interface in Application layer and `ApplicationInsightsTelemetryService` in Infrastructure, emitting a `flag.evaluated` custom event per evaluation
- Registers `NullTelemetryService` (Null Object Pattern) for the Testing environment so integration tests need no connection string

## Key design decisions

- **Dependency Inversion on telemetry** — `BanderasService` depends on `ITelemetryService`, not `TelemetryClient`. Swapping Application Insights for OpenTelemetry requires zero changes to business logic.
- **Custom Event over Trace** — evaluation outcomes are business facts with structured dimensions (`FlagName`, `Result`, `Strategy`, `Environment`), queryable in KQL as `customEvents | where name == "flag.evaluated"`.
- **`FeatureEvaluator` unchanged** — `TrackEvaluation` is called in the imperative shell (`BanderasService`), not the pure core.
- **Connection string from Key Vault** — `appsettings.json` carries an empty placeholder; real value stored as `ApplicationInsights--ConnectionString` in `kv-banderas-dev`.

## Manual step required

Add the Application Insights connection string to `kv-banderas-dev` before deploying:
```
Secret name:  ApplicationInsights--ConnectionString
Value:        <connection string from Azure Portal>
```

## Test plan

- [x] `dotnet build Banderas.sln` — 0 errors, 0 warnings
- [x] `dotnet test --filter "Category=Unit"` — 81/81 passing
- [x] `dotnet test --filter "Category=Integration"` — 32/32 passing
- [x] `dotnet csharpier check .` — clean
- [x] Verify `flag.evaluated` events appear in Application Insights after deploying with a valid connection string