### PR TITLE
docs: add phase 1 architecture audit and update project docs

### DIFF
--- a/Docs/architecture-review-phase1-report.md
+++ b/Docs/architecture-review-phase1-report.md
@@ -1,0 +1,484 @@
+# Architecture Review — Phase 1 / 1.5 Audit Report
+
+---
+
+## 1. Executive Summary
+
+**Overall Health:** Acceptable
+
+**Recommended Gate Decision:** GO WITH CONDITIONS
+
+**Why:**
+
+- Phase 1 established strong seams around controller thinness, evaluator purity, strategy dispatch, and infrastructure abstractions.
+- The current system is buildable, but two debts become materially more expensive in Phase 2: the partial DTO-boundary drift on evaluation and the hard startup dependency on Azure OpenAI configuration.
+- The AI path is reasonably isolated, but its operational behavior and output contract are not yet validated strongly enough to call the platform phase-clean.
+
+---
+
+## 2. Phase Intent vs Actual Outcome
+
+| Intended | Observed | Assessment |
+|---|---|---|
+| Thin controllers | CRUD controllers stay thin, but `EvaluationController` constructs `FeatureEvaluationContext` directly before calling the service. | Partial drift |
+| DTO-only service boundary | `IBanderasService` keeps `Flag` out of signatures, but `IsEnabledAsync` accepts domain value object `FeatureEvaluationContext`. | Drifted |
+| Strategy-based extensibility | `FeatureEvaluator` dispatches by registry and does not require modification for existing strategies. | Aligned |
+| Validation at HTTP boundary | Request DTOs are validated at the controller boundary, but GET query `EnvironmentType` validation happens in `BanderasService`, not before service entry. | Partial drift |
+| Fail-closed evaluation behavior | Missing strategy registrations, malformed JSON, invalid configs, and empty role config all resolve false. | Aligned |
+| AI behind application abstractions | `IAiFlagAnalyzer` and `IPromptSanitizer` keep Semantic Kernel and Azure SDK types out of controllers and core evaluation logic. | Aligned |
+| AI integration should degrade gracefully | Endpoint failures map to 503, but missing `AzureOpenAI:Endpoint` crashes non-testing startup before any endpoint is reachable. | Drifted |
+
+---
+
+## 3. Strong Seams and What Phase 1 Established Well
+
+### Strength: Evaluator and Strategy Isolation
+
+**Why it is strong:**
+
+`FeatureEvaluator` remains a narrow dispatcher with no persistence or telemetry concerns. The strategies stay stateless and independently testable.
+
+**Evidence:**
+
+- `Banderas.Application/Evaluation/FeatureEvaluator.cs`
+- `Banderas.Application/Strategies/NoneStrategy.cs`
+- `Banderas.Application/Strategies/PercentageStrategy.cs`
+- `Banderas.Application/Strategies/RoleStrategy.cs`
+
+**Why it should be preserved:**
+
+This is the cleanest seam in the system and the one most likely to support later rollout strategies without churn.
+
+### Strength: Infrastructure Concerns Stay Behind Interfaces
+
+**Why it is strong:**
+
+Telemetry and AI analysis are expressed as application-layer interfaces and implemented in infrastructure. `BanderasService` does not depend on Application Insights, Semantic Kernel, or Azure SDK types.
+
+**Evidence:**
+
+- `Banderas.Application/Telemetry/ITelemetryService.cs`
+- `Banderas.Application/AI/IAiFlagAnalyzer.cs`
+- `Banderas.Infrastructure/Telemetry/ApplicationInsightsTelemetryService.cs`
+- `Banderas.Infrastructure/AI/AiFlagAnalyzer.cs`
+
+**Why it should be preserved:**
+
+This is the right dependency direction for future observability and AI changes.
+
+### Strength: Validation and Route Guarding Are Explicit
+
+**Why it is strong:**
+
+The mutating endpoints call validators manually and the route-name guard makes the route hardening behavior obvious in code instead of relying on hidden framework magic.
+
+**Evidence:**
+
+- `Banderas.Api/Controllers/BanderasController.cs`
+- `Banderas.Api/Controllers/EvaluationController.cs`
+- `Banderas.Api/Helpers/RouteParameterGuard.cs`
+
+**Why it should be preserved:**
+
+The explicitness helps both reviewability and future debugging.
+
+### Strength: Test Isolation for Azure Dependencies Is Well Designed
+
+**Why it is strong:**
+
+The integration factory forces `Testing`, swaps the DbContext, and injects a stub analyzer so CI never attempts live Azure access.
+
+**Evidence:**
+
+- `Banderas.Tests.Integration/Fixtures/BanderasApiFactory.cs`
+
+**Why it should be preserved:**
+
+This is a strong seam for CI reliability and a prerequisite for evolving the AI surface safely.
+
+---
+
+## 4. Architectural Findings
+
+### Finding: The DTO-only service boundary is not actually preserved on evaluation
+
+**Severity:** Medium  
+**Type:** Fact
+
+**Why it matters:**
+
+The architecture documents describe `IBanderasService` as a hard DTO boundary, but the evaluation path currently requires the API layer to know about `FeatureEvaluationContext`, a domain value object. That weakens the stated controller/service contract and makes boundary rules inconsistent across use cases.
+
+**Evidence:**
+
+- `IBanderasService.IsEnabledAsync(string flagName, FeatureEvaluationContext context, ...)` in `Banderas.Application/Interfaces/IBanderasService.cs`
+- `EvaluationController` constructs `new FeatureEvaluationContext(...)` before calling the service in `Banderas.Api/Controllers/EvaluationController.cs`
+- the pre-audit architecture docs described `IBanderasService` as DTO-only; that wording has now been corrected to match the implemented exception
+
+**Suggested remediation:**
+
+Either:
+
+- restore a strict DTO boundary by changing `IsEnabledAsync` to accept an application DTO, or
+- formally document `FeatureEvaluationContext` as the one accepted boundary exception and stop describing the interface as DTO-only.
+
+**Fix timing:** Now
+
+### Finding: Domain invariants are enforced mainly by outer layers, not by `Flag`
+
+**Severity:** Medium  
+**Type:** Fact
+
+**Why it matters:**
+
+The architecture claims the domain should never be invalid, but `Flag` only guards `Name`. It will accept `EnvironmentType.None`, undefined enum values, or mismatched strategy/config combinations if it is created outside the HTTP validation path. That is manageable today, but it makes future non-HTTP callers and test fixtures more likely to bypass intended rules.
+
+**Evidence:**
+
+- `Flag` constructor checks `name` only in `Banderas.Domain/Entities/Flag.cs`
+- `EnvironmentRules.RequireValid(...)` exists in application, not domain, in `Banderas.Application/Validation/EnvironmentRules.cs`
+- config-shape validation exists in FluentValidation helpers, not domain, in `Banderas.Application/Validators/StrategyConfigRules.cs`
+
+**Suggested remediation:**
+
+Move the minimum non-negotiable invariants into `Flag` itself:
+
+- valid environment
+- valid strategy enum
+- a deliberate normalization rule for `StrategyConfig`
+
+Leave richer JSON semantics at the boundary if needed, but do not let obviously invalid entity state exist.
+
+**Fix timing:** Next phase
+
+### Finding: GET query validation is later than documented
+
+**Severity:** Low  
+**Type:** Fact
+
+**Why it matters:**
+
+The docs describe invalid requests as being rejected at the HTTP boundary before service logic runs, but GET query `EnvironmentType` currently reaches `BanderasService` first. The behavior still returns 400, but the architectural claim is stronger than the implementation.
+
+**Evidence:**
+
+- `BanderasController.GetAllAsync` and `GetByNameAsync` pass `environment` directly to the service in `Banderas.Api/Controllers/BanderasController.cs`
+- service-level validation occurs in `EnvironmentRules.RequireValid(...)` inside `Banderas.Application/Services/BanderasService.cs`
+
+**Suggested remediation:**
+
+Either add explicit controller-boundary handling for query env validation or weaken the documentation claim so it matches reality.
+
+**Fix timing:** Later
+
+---
+
+## 5. Implementation Quality Findings
+
+### Finding: Azure OpenAI configuration is a hard startup dependency for all non-testing environments
+
+**Severity:** High  
+**Type:** Fact
+
+**Why it matters:**
+
+Missing `AzureOpenAI:Endpoint` currently crashes application startup, which means an optional analytical capability can take down unrelated CRUD and evaluation endpoints. That is the wrong blast radius for Phase 1.5.
+
+**Evidence:**
+
+- `Banderas.Infrastructure/DependencyInjection.cs` throws `InvalidOperationException("AzureOpenAI:Endpoint is required.")`
+- `Program.cs` always calls `AddInfrastructure(...)`
+- `Docs/current-state.md` already records this as KI-008, but the implementation note for PR #52 incorrectly says other endpoints remain unaffected
+
+**Suggested remediation:**
+
+Make AI analyzer registration lazy or feature-gated:
+
+- register a no-op/unavailable analyzer when config is missing, or
+- move the configuration check into the analyzer invocation path rather than startup
+
+This preserves 503 behavior for `/api/flags/health` without breaking the whole app.
+
+**Fix timing:** Now
+
+### Finding: AI response integrity is trusted rather than enforced
+
+**Severity:** Medium  
+**Type:** Fact
+
+**Why it matters:**
+
+`AiFlagAnalyzer` deserializes model output into `FlagHealthAnalysisResponse` but does not verify that statuses stay in the allowed set, that every input flag is represented, or that required fields are materially valid. A vendor-side or prompt-side drift can therefore return a structurally deserializable but semantically wrong 200 response.
+
+**Evidence:**
+
+- `AiFlagAnalyzer.AnalyzeAsync(...)` in `Banderas.Infrastructure/AI/AiFlagAnalyzer.cs`
+- `FlagAssessment.Status` is just `string` in `Banderas.Application/DTOs/FlagAssessment.cs`
+- no post-deserialization validation logic exists in application or infrastructure
+
+**Suggested remediation:**
+
+Add a small post-deserialization verifier:
+
+- enforce allowed status values
+- enforce non-empty summary and recommendation fields
+- enforce one result per analyzed flag or fail closed to `AiAnalysisUnavailableException`
+
+**Fix timing:** Now
+
+---
+
+## 6. Testing and Reliability Findings
+
+### Finding: The AI unhappy path is not covered end-to-end
+
+**Severity:** Medium  
+**Type:** Fact
+
+**Why it matters:**
+
+The code claims graceful degradation to 503, but there is no end-to-end test proving that the middleware returns the documented 503 ProblemDetails shape when AI analysis fails. The current integration test setup always injects a successful stub analyzer.
+
+**Evidence:**
+
+- `Banderas.Tests.Integration/Fixtures/BanderasApiFactory.cs` always registers `StubAiFlagAnalyzer`
+- `Banderas.Tests.Integration/AnalyzeFlagsEndpointTests.cs` covers only 200 and 400 paths
+- only unit-level propagation is covered in `Banderas.Tests/AI/BanderasServiceAnalysisTests.cs`
+
+**Suggested remediation:**
+
+Add one integration test factory path that injects a failing analyzer and assert:
+
+- 503 status
+- `application/problem+json`
+- correct RFC 9110 type URI
+
+**Fix timing:** Now
+
+### Finding: Domain tests do not match the documented importance of domain integrity
+
+**Severity:** Medium  
+**Type:** Fact
+
+**Why it matters:**
+
+The project documents domain integrity as a core principle, but the direct tests on `Flag` cover only seeded provenance and default config normalization. The highest-value entity rules are not exercised close to the entity.
+
+**Evidence:**
+
+- `Banderas.Tests/Domain/FlagTests.cs` contains only two tests, both focused on `IsSeeded`
+- no direct tests cover `Update`, `Archive`, invalid environment values, or invalid strategy values
+
+**Suggested remediation:**
+
+Expand `FlagTests` around the invariants that the audit depends on. If those invariants remain intentionally outside the entity, make that explicit in the docs rather than implying stronger domain protection than exists.
+
+**Fix timing:** Next phase
+
+### Finding: Current local verification is harder to trust than it should be
+
+**Severity:** Low  
+**Type:** Fact
+
+**Why it matters:**
+
+The test suite exits successfully, but this environment did not surface a clean per-test summary through the CLI capture path. That is not a product bug, but it is a workflow reliability issue for future audits and CI debugging.
+
+**Evidence:**
+
+- local `dotnet test` reruns during the audit exited `0`
+- in-sandbox runs failed on MSBuild named-pipe permissions
+- escalated runs succeeded but did not emit useful VSTest summaries through this terminal capture
+
+**Suggested remediation:**
+
+No production change required. For future audits, prefer CI artifacts or explicit `.trx` handling in a shell environment known to preserve test output.
+
+**Fix timing:** Later
+
+---
+
+## 7. Security and Operational Findings
+
+### Finding: The current AI startup failure mode is fail-stop, not endpoint-scoped fail-closed
+
+**Severity:** High  
+**Type:** Fact
+
+**Why it matters:**
+
+The security model prefers fail-closed behavior for sensitive features. For AI analysis, the healthier equivalent is endpoint-scoped unavailability. Today the service fails before boot, which is operationally harsher than the documented 503 behavior.
+
+**Evidence:**
+
+- startup exception in `Banderas.Infrastructure/DependencyInjection.cs`
+- 503 middleware path in `Banderas.Api/Middleware/GlobalExceptionMiddleware.cs`
+
+**Suggested remediation:**
+
+Keep AI failures local to `/api/flags/health` by moving failure detection after startup.
+
+**Fix timing:** Now
+
+### Finding: The route and DTO validation story is materially stronger than the repository layer story
+
+**Severity:** Low  
+**Type:** Inference
+
+**Why it matters:**
+
+Repository calls are safe because EF Core parameterizes queries, but architectural confidence currently depends heavily on outer-layer validation and conventions rather than the domain model itself. That is workable for the current HTTP-only shape, but it increases risk as soon as another input surface appears.
+
+**Evidence:**
+
+- repository queries are LINQ-only in `Banderas.Infrastructure/Persistence/BanderasRepository.cs`
+- `InputSanitizer` and validators carry most structural protection in `Banderas.Application/Validators/*`
+- `Flag` itself remains permissive in `Banderas.Domain/Entities/Flag.cs`
+
+**Suggested remediation:**
+
+Preserve the validator and route-guard approach, but add a smaller set of domain-level non-negotiables before new ingestion surfaces arrive.
+
+**Fix timing:** Next phase
+
+---
+
+## 8. AI and Prompt Safety Findings
+
+### Finding: The AI boundary is clean, but the contract boundary is still soft
+
+**Severity:** Medium  
+**Type:** Fact
+
+**Why it matters:**
+
+The good news is that AI concerns have not leaked into controllers, strategies, or the core evaluator. The remaining weakness is not architectural contamination; it is contract trust after the model responds.
+
+**Evidence:**
+
+- clean interface split via `IPromptSanitizer` and `IAiFlagAnalyzer`
+- Semantic Kernel usage confined to `Banderas.Infrastructure/AI/AiFlagAnalyzer.cs`
+- no post-parse semantic validation of AI output
+
+**Suggested remediation:**
+
+Keep the current abstraction split and add response validation plus one failing integration path.
+
+**Fix timing:** Now
+
+---
+
+## 9. Technical Debt Register
+
+| ID | Debt Item | Severity | Why It Exists | Impact | Suggested Fix | Fix Timing |
+|---|---|---|---|---|---|---|
+| TD-001 | `FeatureEvaluationContext` crosses `IBanderasService` boundary | Medium | Evaluation path predates a fully consistent DTO boundary | Inconsistent controller/service contract | Replace with application DTO or explicitly document the exception | Now |
+| TD-002 | AI config crash at startup | High | Analyzer wiring is validated in DI, not at use time | Entire app can fail before boot in non-testing envs | Make analyzer registration/config lazy or degrade to unavailable analyzer | Now |
+| TD-003 | `Flag` invariants are under-enforced | Medium | Validation concentrated at HTTP boundary during MVP | Future non-HTTP callers can create invalid entities | Move minimum invariants into `Flag` | Next phase |
+| TD-004 | AI response semantics unverified | Medium | Structured output is trusted after JSON parse | Possible incorrect 200 responses from model drift | Add semantic response validation | Now |
+| TD-005 | AI unhappy path not integration-tested | Medium | Test factory always injects successful stub analyzer | 503 contract can regress silently | Add failing-analyzer integration test | Now |
+
+---
+
+## 10. Risks for Phase 2
+
+- What becomes painful if left alone:
+  The Azure OpenAI startup dependency and boundary inconsistency will keep leaking into unrelated Phase 2 work.
+- What assumptions are currently unproven:
+  That AI failures consistently degrade to the documented 503 shape, and that model output always respects the expected response contract.
+- What weak seams could slow upcoming work:
+  The evaluation boundary inconsistency and permissive domain entity rules will complicate any future SDK, CLI, or alternate ingestion surface.
+- What parts of the system invite accidental complexity in the next phase:
+  AI wiring in DI, ad hoc repository filter growth, and documentation that still describes stricter boundaries than the code enforces.
+
+---
+
+## 11. Recommended Refactors Before Phase 2
+
+### Fix Now
+
+- Decouple Azure OpenAI configuration from global app startup so `/api/flags/health` can fail independently.
+- Decide the evaluation boundary: restore a DTO-only service contract or explicitly ratify the `FeatureEvaluationContext` exception.
+- Add contract enforcement and an unhappy-path integration test for AI analysis.
+
+### Fix Soon
+
+- Strengthen `Flag` invariants and expand direct domain tests.
+- Clean up the remaining documentation drift around smoke-test path casing and service-boundary wording.
+
+### Safe to Defer
+
+- Replace nullable repository filtering with a richer `FlagQuery` object.
+- Expand telemetry beyond evaluation events.
+- Add dynamic strategy registration ergonomics beyond the current registry dispatch.
+
+---
+
+## 12. Documentation Updates Required
+
+The audit resulted in these documentation changes:
+
+- `Docs/current-state.md`
+  Updated phase status, gate decision, known issues, current focus, and smoke-test path casing.
+- `Docs/roadmap.md`
+  Marked the architecture review complete, recorded the gate as GO WITH CONDITIONS, and adjusted current focus.
+- `Docs/architecture.md`
+  Clarified that the current implementation preserves the entity boundary but still leaks `FeatureEvaluationContext` across the service boundary.
+
+No additional `Docs/Decisions/.../implementation-notes.md` file was amended in this pass. The audit report itself captures the durable deltas and debt.
+
+---
+
+## 13. Final Gate Verdict
+
+### GO WITH CONDITIONS
+
+Phase 2 may begin, but only with the current debt explicitly carried forward and a short pre-Phase-2 fix list owned up front:
+
+- remove the Azure OpenAI startup blast radius
+- close the AI unhappy-path and output-contract gaps
+- resolve or formally document the evaluation boundary exception
+
+---
+
+## Scorecard Template
+
+| Area | Score (1-5) | Notes |
+|---|---:|---|
+| Architecture / boundaries | 3 | Strong layering overall, but the evaluation path violates the stated DTO-only service boundary. |
+| Domain model integrity | 3 | Controlled mutation exists, but key invariants still live outside the entity. |
+| Application orchestration | 4 | Service orchestration is readable and appropriately central. |
+| Evaluation engine design | 4 | Pure, deterministic, and easy to extend for current strategy set. |
+| Strategy extensibility | 4 | Existing evaluator seam is clean; future strategy additions still need validator/config work. |
+| Persistence design | 4 | Repository and EF usage are disciplined; uniqueness handling is pragmatic. |
+| Validation / sanitization | 4 | Explicit and mostly strong, with a small GET/query boundary mismatch. |
+| API / error handling | 4 | Consistent ProblemDetails behavior, but the AI 503 path lacks end-to-end proof. |
+| AI boundary quality | 3 | Abstractions are clean; startup coupling and output-contract trust reduce confidence. |
+| Observability seams | 4 | Evaluation telemetry abstraction is well-placed. |
+| Test quality | 3 | Good breadth, but important AI and domain-invariant gaps remain. |
+| Readiness for Phase 2 | 3 | Viable with conditions, not clean enough for an unconditional go. |
+
+---
+
+## Top 5 Priority Actions Template
+
+1. Move Azure OpenAI endpoint validation out of startup so the AI endpoint can fail independently.
+2. Resolve the `IBanderasService` boundary drift on `FeatureEvaluationContext`.
+3. Add semantic validation of AI responses before returning 200.
+4. Add an integration test for `AiAnalysisUnavailableException` -> 503 ProblemDetails.
+5. Strengthen `Flag` invariants and direct domain tests before adding new input surfaces.
+
+---
+
+## Architecture Delta Summary Template
+
+- Intended:
+  `IBanderasService` as a DTO-only application boundary with validation rejected before service code and AI analysis degrading per endpoint.
+- Actual:
+  The entity boundary is preserved, but evaluation still crosses the service boundary with `FeatureEvaluationContext`, GET env validation partially occurs in the service layer, and Azure OpenAI configuration can fail the app at startup.
+- Why the delta exists:
+  The implementation favored incremental delivery and reuse of the existing domain evaluation context over a stricter service contract, and AI wiring was added at DI time for simplicity.
+- Is it acceptable, temporary, or dangerous:
+  Acceptable short term, but the startup coupling is dangerous enough to fix before broader Phase 2 work.
+- Revisit by:
+  Start of Phase 2.

--- a/Docs/architecture-review-phase1.md
+++ b/Docs/architecture-review-phase1.md
@@ -92,7 +92,7 @@ Optional but useful:
 
 ---
 
-## How the Audit Should Think
+## How the Auditor Should Think
 
 The reviewing model should behave like a **technical auditor**, not a cheerleader.
 

--- a/Docs/architecture.md
+++ b/Docs/architecture.md
@@ -77,10 +77,12 @@ The system follows a **layered architecture with strong separation of concerns**
   Domain and service never see bad data
      ↓
 [ Controllers (API Layer) ]
-  DTOs in, DTOs out — no domain knowledge
+  DTOs in, DTOs out for CRUD and AI flows
+  Current exception: evaluation controller constructs FeatureEvaluationContext
      ↓
 [ Application Layer (IBanderasService) ]
-  Speaks entirely in DTOs — Flag entity never crosses this boundary
+  Flag entity never crosses this boundary
+  Current exception: IsEnabledAsync accepts FeatureEvaluationContext
   Applies InputSanitizer to evaluation context before passing to evaluator
      ↓
 [ Evaluation Engine (FeatureEvaluator) ]
@@ -106,9 +108,11 @@ The system follows a **layered architecture with strong separation of concerns**
 
 **Key Characteristics:**
 
-* Thin controllers — no business logic, no domain knowledge
+* Thin controllers — no business logic, minimal domain knowledge
 * Delegates all work to application layer via `IBanderasService`
 * Receives and returns DTOs only — never touches domain entities
+* Current exception: `EvaluationController` constructs `FeatureEvaluationContext`
+  before calling the service
 * Calls `ValidateAsync()` manually on mutating actions (POST, PUT) — validation
   runs at the top of each action before any service code executes
 * Swagger/OpenAPI enabled at `/openapi/v1.json`
@@ -128,7 +132,7 @@ The system follows a **layered architecture with strong separation of concerns**
   registered as `Scoped` services via explicit `AddScoped<IValidator<T>, TValidator>()`
   calls in `DependencyInjection.cs`. Controllers inject `IValidator<T>` and call
   `ValidateAsync()` manually at the top of each mutating action.
-* All three request DTOs have dedicated `AbstractValidator<T>` implementations
+* All four request DTOs have dedicated `AbstractValidator<T>` implementations
   in `Banderas.Application/Validators/`
 * `InputSanitizer` is a shared static helper — trims whitespace, strips ASCII control
   characters below 0x20 (except tab) from all string inputs
@@ -147,6 +151,7 @@ The system follows a **layered architecture with strong separation of concerns**
 | `CreateFlagRequestValidator` | `CreateFlagRequest` | Name allowlist regex, env sentinel guard, StrategyConfig cross-field rules, 2000-char limit |
 | `UpdateFlagRequestValidator` | `UpdateFlagRequest` | StrategyConfig cross-field rules, 2000-char limit |
 | `EvaluationRequestValidator` | `EvaluationRequest` | UserId max 256, UserRoles max 50 entries × 100 chars each, env sentinel guard |
+| `FlagHealthRequestValidator` | `FlagHealthRequest` | Optional staleness threshold constrained to 1–365 days |
 
 **Input Limits (enforced at HTTP boundary):**
 
@@ -187,7 +192,8 @@ access. `InputSanitizer` is the single source of truth for both surfaces.
 
 **Key Characteristics:**
 
-* `IBanderasService` interface speaks entirely in DTOs
+* `IBanderasService` keeps `Flag` entities out of method signatures
+* Current exception: `IsEnabledAsync` accepts `FeatureEvaluationContext`
 * `Flag` entity is constructed and mapped inside `BanderasService` — never exposed
   to callers
 * `ToResponse()` mapping is called inside the service, not in controllers
@@ -199,6 +205,12 @@ access. `InputSanitizer` is the single source of truth for both surfaces.
 
 > `Flag` domain entity must never appear in any `IBanderasService` method signature.
 > The controller layer must never call `.ToResponse()` directly.
+
+**Current implementation note (audit 2026-04-22):**
+
+`FeatureEvaluationContext` still crosses the controller → service boundary on the
+evaluation path. Treat this as current boundary debt, not as evidence that the
+entity boundary has been removed.
 
 ---
 

--- a/Docs/current-state.md
+++ b/Docs/current-state.md
@@ -31,7 +31,7 @@
 **Phase 1 — Evaluation Decision Logging (PR #48): ✅ Complete**
 **Phase 1 — NuGet Locked Restore (rolled into PR #48): ✅ Complete**
 **Phase 1 — Seed Data for Local Development (PR #49): ✅ Complete**
-**Phase 1 — Smoke Test File (`requests/smoke-test.http`): ✅ Complete**
+**Phase 1 — Smoke Test File (`Requests/smoke-test.http`): ✅ Complete**
 
 **🎉 Phase 1 — MVP Completion: ✅ COMPLETE**
 
@@ -39,7 +39,11 @@
 **Phase 1.5 — Application Insights Integration (PR #51): ✅ Complete**
 **Phase 1.5 — AI Flag Health Analysis Endpoint (PR #52): ✅ Complete**
 
-**Phase 1.5 — Azure Foundation + AI Integration: 🔲 Architecture Review Remaining**
+**Phase 1.5 — Azure Foundation + AI Integration: ✅ Architecture Review Complete**
+
+**Gate Decision:** GO WITH CONDITIONS
+
+Audit report: `Docs/architecture-review-phase1-report.md`
 
 144/144 tests passing (107 unit + 37 integration).
 
@@ -71,7 +75,8 @@
 - `BanderasService` — async, orchestrates repository + evaluator + logging + telemetry
   + prompt sanitization + AI analysis
 - `IBanderasService` — async signatures with `CancellationToken`, full CRUD + evaluation
-  + `AnalyzeFlagsAsync`
+  + `AnalyzeFlagsAsync`; current evaluation path still accepts
+  `FeatureEvaluationContext` directly (tracked by the audit as boundary debt)
 - DTOs: `CreateFlagRequest`, `UpdateFlagRequest`, `FlagResponse`, `EvaluationRequest`,
   `FlagMappings`, `FlagHealthRequest`, `FlagAssessment`, `FlagHealthAnalysisResponse`
 - `FlagResponse.StrategyConfig` — `string?` (nullable); flags with `RolloutStrategy.None`
@@ -142,16 +147,17 @@
 
 ### Developer Experience
 
-- `requests/smoke-test.http` — all endpoints covered including `POST /api/flags/health`
+- `Requests/smoke-test.http` — all endpoints covered including `POST /api/flags/health`
   (default threshold + `stalenessThresholdDays: 7` variants)
 - `DatabaseSeeder` — six seed flags available immediately on `docker compose up`
 
 ---
 
-## 🚧 What Is Not Yet Built — Phase 1.5 Remaining
+## 🚧 What Is Not Yet Built — Follow-Up From The Audit
 
-- [ ] Architecture Review Document — technical health audit before Phase 2;
-  committed to `Docs/architecture-review-phase1.md`
+- [ ] Remove the Azure OpenAI startup dependency from the global app boot path
+- [ ] Resolve or explicitly ratify the `FeatureEvaluationContext` service-boundary exception
+- [ ] Add end-to-end coverage for AI-unavailable `503` behavior and tighten AI response validation
 
 ---
 
@@ -166,8 +172,9 @@ not `localhost`. This is correct for the devcontainer environment. Do not change
 
 ### KI-008 (Manual Step) — `AzureOpenAI--Endpoint` Key Vault secret not yet added
 
-`POST /api/flags/health` will throw `InvalidOperationException` at startup if
-`AzureOpenAI:Endpoint` is missing and the environment is not `Testing`.
+Application startup will throw `InvalidOperationException` if `AzureOpenAI:Endpoint`
+is missing and the environment is not `Testing`. This currently blocks all endpoints,
+not just `POST /api/flags/health`.
 
 **Fix:** Add to Key Vault before deploying:
 ```
@@ -179,16 +186,36 @@ Secret name:  AzureOpenAI--DeploymentName   (optional — defaults to gpt-5-mini
 Value:        <deployment name if overriding>
 ```
 
+### KI-009 — `FeatureEvaluationContext` still crosses the service boundary
+
+`IBanderasService.IsEnabledAsync` accepts the domain value object
+`FeatureEvaluationContext`, and `EvaluationController` constructs that value object
+directly. This preserves the entity boundary but does not preserve the documented
+DTO-only service boundary.
+
+**Audit status:** Identified in `Docs/architecture-review-phase1-report.md`.
+Resolve before or during early Phase 2.
+
+### KI-010 — AI response semantics are not validated after deserialization
+
+`AiFlagAnalyzer` deserializes model output into `FlagHealthAnalysisResponse` but does
+not verify that every flag is represented or that status values stay within the
+documented set.
+
+**Audit status:** Identified in `Docs/architecture-review-phase1-report.md`.
+Fix in early Phase 2.
+
 ---
 
 ## 🎯 Current Focus
 
-**Phase 1.5 — Azure Foundation + AI Integration**
+**Phase 2 Prep — Gate: GO WITH CONDITIONS**
 
 ### Immediate Next Tasks
 
-1. Architecture Review Document (`Docs/architecture-review-phase1.md`) — required
-   before Phase 2 begins
+1. Remove the Azure OpenAI startup blast radius so AI unavailability stays endpoint-scoped
+2. Resolve or explicitly document the evaluation boundary exception on `IBanderasService`
+3. Add AI unhappy-path and response-contract coverage before broadening Phase 2 work
 
 ---
 
@@ -199,7 +226,8 @@ Value:        <deployment name if overriding>
 - No advanced rollout strategies yet (Phase 5)
 - No UI work
 - Do not change `Host=postgres` back to `localhost` in connection string
-- Do not start Phase 2 until Architecture Review is committed
+- Do not start broad Phase 2 work until the gate-condition fixes are either completed
+  or consciously deferred in writing
 
 ---
 
@@ -228,8 +256,11 @@ Value:        <deployment name if overriding>
 - [x] AI flag health analysis endpoint — `POST /api/flags/health`; natural language
   flag status via Azure OpenAI + Semantic Kernel; `IPromptSanitizer` introduced;
   DEFERRED-004 closed
-- [ ] Architecture Review Document committed to `Docs/`
+- [x] Architecture Review completed — see `Docs/architecture-review-phase1-report.md`
 
+**Phase 1.5 DoD: ✅ COMPLETE**
+
+**Phase gate:** GO WITH CONDITIONS
 ---
 
 ## 📝 Spec Writing — Lessons Learned
@@ -262,7 +293,8 @@ Value:        <deployment name if overriding>
 ## 🧩 Notes for AI Assistants
 
 - Clean Architecture: Controller → Service → Evaluator → Strategy → Repository
-- `IBanderasService` speaks entirely in DTOs — no `Flag` entity crosses the service boundary
+- `Flag` does not cross the service boundary; current implementation still passes
+  `FeatureEvaluationContext` into `IBanderasService.IsEnabledAsync`
 - `IBanderasRepository.GetAllAsync` accepts `EnvironmentType? environment = null`;
   null means no environment filter (cross-environment query for health analysis)
 - `FlagResponse.StrategyConfig` is `string?` — null guard required before sanitizing

--- a/Docs/roadmap.md
+++ b/Docs/roadmap.md
@@ -58,7 +58,7 @@ Every phase of this roadmap builds toward that demo.
 |-------|------|--------|
 | 0 | Foundation | ✅ Complete |
 | 1 | MVP Completion | ✅ Complete |
-| 1.5 | Azure Foundation + AI Integration | 🔄 In Progress |
+| 1.5 | Azure Foundation + AI Integration | ✅ Complete — Gate: GO WITH CONDITIONS |
 | 2 | Testing & Reliability | Planned |
 | 3 | Auth, Authorization & Rate Limiting | Planned |
 | 4 | Observability & Debugging | Planned |
@@ -77,7 +77,7 @@ Every phase of this roadmap builds toward that demo.
 * [x] `PercentageStrategy`, `RoleStrategy`, `NoneStrategy`
 * [x] EF Core + Postgres repository
 * [x] Controllers wired, Scalar UI configured
-* [x] Service interface boundary — `IBanderasService` speaks entirely in DTOs
+* [x] Service interface boundary — `Flag` entity stays out of `IBanderasService` signatures
 
 ---
 
@@ -95,13 +95,13 @@ Every phase of this roadmap builds toward that demo.
 * [x] Evaluation decision logging
 * [x] NuGet locked restore
 * [x] `DatabaseSeeder` — six seed flags, all three strategies
-* [x] `requests/smoke-test.http` — all endpoints covered
+* [x] `Requests/smoke-test.http` — all endpoints covered
 
 **Phase 1 DoD: ✅ COMPLETE — 113/113 tests passing**
 
 ---
 
-## 🌩️ Phase 1.5 — Azure Foundation + AI Integration 🔄 In Progress
+## 🌩️ Phase 1.5 — Azure Foundation + AI Integration ✅ Complete
 
 ### Azure Infrastructure ✅ Provisioned
 
@@ -143,18 +143,27 @@ Every phase of this roadmap builds toward that demo.
 * [x] 31 new tests (21 unit sanitizer + 5 unit service + 5 integration)
 * [x] 144/144 tests passing
 
-### Architecture Review 🔲 Not Started
+### Architecture Review ✅ Complete
 
-* [ ] Technical health audit document — `Docs/architecture-review-phase1.md`
-* [ ] Strong seams, accumulating complexity, conscious debt inventory
-* [ ] Required gate before Phase 2 begins
+* [x] Technical health audit report — `Docs/architecture-review-phase1-report.md`
+* [x] Strong seams, accumulating complexity, and debt inventory recorded
+* [x] Gate decision recorded: GO WITH CONDITIONS
 
-**Phase 1.5 DoD: complete when architecture review committed**
+**Phase 1.5 DoD: ✅ COMPLETE**
+
+**Carry-forward conditions before broad Phase 2 work:**
+
+* [ ] Remove Azure OpenAI as a hard startup dependency for non-AI endpoints
+* [ ] Resolve or explicitly document the `FeatureEvaluationContext` service-boundary exception
+* [ ] Add AI unhappy-path and output-contract verification
 
 ---
 
 ## 🧪 Phase 2 — Testing & Reliability
 
+* [ ] Add integration coverage for AI-unavailable `503` behavior
+* [ ] Enforce AI response semantics after deserialization
+* [ ] Decide whether evaluation returns to a DTO-only service boundary or formally keeps the value-object exception
 * [ ] Contract tests for API responses
 * [ ] Handle invalid strategy configurations gracefully
 * [ ] Test environment-specific behavior edge cases
@@ -234,18 +243,21 @@ Every phase of this roadmap builds toward that demo.
 
 ## 🎯 Current Focus
 
-**Phase 1.5 — Azure Foundation + AI Integration**
+**Phase 2 Prep — Gate: GO WITH CONDITIONS**
 
-1. Architecture Review Document (`Docs/architecture-review-phase1.md`)
+1. Remove the Azure OpenAI startup blast radius
+2. Close the AI unhappy-path and response-contract gaps
+3. Resolve or explicitly document the evaluation boundary exception
 
-**Phase 1.5 DoD: complete when architecture review is committed**
+**Phase 1.5 closed with GO WITH CONDITIONS**
 
 ---
 
 ## 🧩 Notes for AI Assistants (Claude Context)
 
 * Architecture follows Clean Architecture: Controller → Service → Evaluator → Strategy → Repository
-* `IBanderasService` speaks entirely in DTOs — no `Flag` entity crosses the service boundary
+* `Flag` does not cross the service boundary; current implementation still passes
+  `FeatureEvaluationContext` into `IBanderasService.IsEnabledAsync`
 * `IBanderasRepository.GetAllAsync` accepts `EnvironmentType? environment = null`;
   null means no environment filter (cross-environment health analysis)
 * `FlagResponse.StrategyConfig` is `string?` — null guard required before sanitizing

--- a/claude.md
+++ b/claude.md
@@ -22,6 +22,7 @@ Act as a senior .NET backend engineer focused on:
 - Maintainable, production-quality code
 - AI Dev Workflows
 - Cloud Development and Deployment
+- Functional Programming
 
 Your responsibility is to:
 - Analyze the specs, check for issues


### PR DESCRIPTION
## Summary
- add the Phase 1 / 1.5 architecture audit report in its own doc
- update `current-state`, `roadmap`, and `architecture` to reflect the audit verdict and the documented implementation deltas
- include the current local updates to `Docs/architecture-review-phase1.md` and `claude.md` in the same commit, per request

## Audit Result
- gate verdict: `GO WITH CONDITIONS`
- primary carry-forward items:
  - remove Azure OpenAI as a hard startup dependency for non-AI endpoints
  - resolve or explicitly document the `FeatureEvaluationContext` service-boundary exception
  - add AI unhappy-path and output-contract verification

## Files
- `Docs/architecture-review-phase1-report.md`
- `Docs/architecture-review-phase1.md`
- `Docs/architecture.md`
- `Docs/current-state.md`
- `Docs/roadmap.md`
- `claude.md`

## Notes
- branch: `feature-phase1-architecture-audit-docs`
- commit: `8953112`
- no code or runtime behavior changes are included in this PR