### PR TITLE
Fix/enforce archive state as terminal

### DIFF
--- a/Banderas.Domain/Entities/Flag.cs
+++ b/Banderas.Domain/Entities/Flag.cs
@@ -1,4 +1,5 @@
 using Banderas.Domain.Enums;
+using Banderas.Domain.Exceptions;
 
 namespace Banderas.Domain.Entities;
 
@@ -57,12 +58,22 @@ public class Flag
 
     public void SetEnabled(bool enabled)
     {
+        if (IsArchived)
+        {
+            throw new FlagDomainException($"Flag '{Name}' is archived and cannot be modified.");
+        }
+
         IsEnabled = enabled;
         UpdatedAt = DateTime.UtcNow;
     }
 
     public void UpdateStrategy(RolloutStrategy strategyType, string? strategyConfig)
     {
+        if (IsArchived)
+        {
+            throw new FlagDomainException($"Flag '{Name}' is archived and cannot be modified.");
+        }
+
         StrategyType = strategyType;
         StrategyConfig = strategyConfig ?? "{}";
         UpdatedAt = DateTime.UtcNow;
@@ -70,6 +81,11 @@ public class Flag
 
     public void UpdateName(string name)
     {
+        if (IsArchived)
+        {
+            throw new FlagDomainException($"Flag '{Name}' is archived and cannot be modified.");
+        }
+
         if (string.IsNullOrWhiteSpace(name))
         {
             throw new ArgumentException("Name cannot be empty.", nameof(name));
@@ -85,6 +101,11 @@ public class Flag
     /// </summary>
     public void Update(bool isEnabled, RolloutStrategy strategyType, string? strategyConfig)
     {
+        if (IsArchived)
+        {
+            throw new FlagDomainException($"Flag '{Name}' is archived and cannot be modified.");
+        }
+
         IsEnabled = isEnabled;
         StrategyType = strategyType;
         StrategyConfig = strategyConfig ?? "{}";
@@ -93,6 +114,11 @@ public class Flag
 
     public void Archive()
     {
+        if (IsArchived)
+        {
+            throw new FlagDomainException($"Flag '{Name}' is archived and cannot be modified.");
+        }
+
         IsArchived = true;
         ArchivedAt = DateTime.UtcNow;
         UpdatedAt = DateTime.UtcNow;

--- a/Banderas.Domain/Exceptions/FlagDomainException.cs
+++ b/Banderas.Domain/Exceptions/FlagDomainException.cs
@@ -1,0 +1,13 @@
+using Microsoft.AspNetCore.Http;
+
+namespace Banderas.Domain.Exceptions;
+
+/// <summary>
+/// Thrown when an operation violates a domain invariant on Flag.
+/// Maps to HTTP 409 Conflict.
+/// </summary>
+public sealed class FlagDomainException : BanderasException
+{
+    public FlagDomainException(string message)
+        : base(message, StatusCodes.Status409Conflict) { }
+}

--- a/Banderas.Tests/Domain/FlagArchivedInvariantTests.cs
+++ b/Banderas.Tests/Domain/FlagArchivedInvariantTests.cs
@@ -1,0 +1,130 @@
+using Banderas.Domain.Entities;
+using Banderas.Domain.Enums;
+using Banderas.Domain.Exceptions;
+using Banderas.Tests.Helpers;
+using FluentAssertions;
+
+namespace Banderas.Tests.Domain;
+
+[Trait("Category", "Unit")]
+public sealed class FlagArchivedInvariantTests
+{
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void SetEnabled_WhenFlagIsArchived_ThrowsFlagDomainException()
+    {
+        Flag flag = FlagBuilder.Build();
+        flag.Archive();
+
+        Action act = () => flag.SetEnabled(true);
+
+        act.Should().Throw<FlagDomainException>();
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void UpdateStrategy_WhenFlagIsArchived_ThrowsFlagDomainException()
+    {
+        Flag flag = FlagBuilder.Build();
+        flag.Archive();
+
+        Action act = () => flag.UpdateStrategy(RolloutStrategy.None, null);
+
+        act.Should().Throw<FlagDomainException>();
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void UpdateName_WhenFlagIsArchived_ThrowsFlagDomainException()
+    {
+        Flag flag = FlagBuilder.Build();
+        flag.Archive();
+
+        Action act = () => flag.UpdateName("new-name");
+
+        act.Should().Throw<FlagDomainException>();
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Update_WhenFlagIsArchived_ThrowsFlagDomainException()
+    {
+        Flag flag = FlagBuilder.Build();
+        flag.Archive();
+
+        Action act = () => flag.Update(false, RolloutStrategy.None, null);
+
+        act.Should().Throw<FlagDomainException>();
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Archive_WhenFlagIsAlreadyArchived_ThrowsFlagDomainException()
+    {
+        Flag flag = FlagBuilder.Build();
+        flag.Archive();
+
+        Action act = () => flag.Archive();
+
+        act.Should().Throw<FlagDomainException>();
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void SetEnabled_WhenFlagIsNotArchived_Succeeds()
+    {
+        Flag flag = FlagBuilder.Build(isEnabled: false);
+
+        flag.SetEnabled(true);
+
+        flag.IsEnabled.Should().BeTrue();
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void UpdateStrategy_WhenFlagIsNotArchived_Succeeds()
+    {
+        Flag flag = FlagBuilder.Build();
+
+        flag.UpdateStrategy(RolloutStrategy.Percentage, "{\"percentage\":50}");
+
+        flag.StrategyType.Should().Be(RolloutStrategy.Percentage);
+        flag.StrategyConfig.Should().Be("{\"percentage\":50}");
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void UpdateName_WhenFlagIsNotArchived_Succeeds()
+    {
+        Flag flag = FlagBuilder.Build();
+
+        flag.UpdateName("renamed-flag");
+
+        flag.Name.Should().Be("renamed-flag");
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Update_WhenFlagIsNotArchived_Succeeds()
+    {
+        Flag flag = FlagBuilder.Build(isEnabled: true);
+
+        flag.Update(false, RolloutStrategy.Percentage, "{\"percentage\":25}");
+
+        flag.IsEnabled.Should().BeFalse();
+        flag.StrategyType.Should().Be(RolloutStrategy.Percentage);
+        flag.StrategyConfig.Should().Be("{\"percentage\":25}");
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public void Archive_WhenFlagIsNotArchived_Succeeds()
+    {
+        Flag flag = FlagBuilder.Build();
+
+        flag.Archive();
+
+        flag.IsArchived.Should().BeTrue();
+        flag.ArchivedAt.Should().NotBeNull();
+    }
+}

--- a/Docs/Decisions/enforce-archive-state-as-terminal - PR# 59/implementation-notes.md
+++ b/Docs/Decisions/enforce-archive-state-as-terminal - PR# 59/implementation-notes.md
@@ -1,0 +1,88 @@
+# Enforce Archived State as Terminal — Implementation Notes
+
+**Session date:** 2026-05-01
+**Branch:** `dev`
+**Spec reference:** `Docs/Decisions/enforce-archive-state-as-terminal - PR# 59/spec.md`
+**Build status:** `dotnet build Banderas.sln` passed with 0 warnings and 0 errors
+**Tests:** New `FlagArchivedInvariantTests` passing (10/10); full unit suite green (117/117)
+**PR:** #59
+
+## What Was Built
+
+`Flag` now treats archival as a terminal state. Every mutation method on the entity (`SetEnabled`, `UpdateStrategy`, `UpdateName`, `Update`, `Archive`) carries a guard clause as its first statement: if `IsArchived` is `true`, the method throws a new `FlagDomainException` with a message that names the flag. The exception extends `BanderasException` with `StatusCode = 409`, so the existing `GlobalExceptionMiddleware` catches it and writes a `409 Conflict` ProblemDetails response without any middleware change.
+
+The change is contained entirely within the Domain layer — no controllers, services, repositories, or migrations were touched.
+
+## Why This Change
+
+The DDD audit (`Docs/Decisions/flag-ddd-analysis-backlog.md`) flagged that `Flag` allowed silent mutation after archival: `SetEnabled`, `Update*`, and even a second `Archive()` would succeed, advance `UpdatedAt`, and persist. That is incorrect domain behavior — an archived flag is a historical record, and mutations are either caller bugs or out-of-band operations that need an authorized, audited code path (deferred to Phase 3). Encoding the rule on the entity itself, rather than in a service or validator, follows the "make illegal states unrepresentable" principle and keeps the invariant in the only place that owns it.
+
+## Key Decisions
+
+**Single `FlagDomainException` over per-violation exception types.** The message carries the specificity; the type carries the HTTP status. Adding a new invariant in the future is a `throw new FlagDomainException(...)` — no new middleware case, no new exception class. This matches how `DuplicateFlagNameException` works today (a single type per violation category, not per field).
+
+**Guard `Archive()` itself, not just the other four mutations.** Calling `Archive()` on an already-archived flag is almost always a caller bug; making it a silent no-op would hide that. Throwing surfaces it.
+
+**Archived-guard runs *before* the existing whitespace-name guard in `UpdateName`.** This is an observable behavior shift: `UpdateName("")` on an archived flag now throws `FlagDomainException` instead of `ArgumentException`. Documented in the spec; no existing caller depends on the previous order.
+
+**Domain throws, middleware catches — no intermediary handling.** `FlagDomainException : BanderasException` plugs directly into the existing `BanderasException` catch block. The 409 case in `GetTitleForStatusCode` was already present from prior work on `DuplicateFlagNameException`, so AC-4 was a verification step, not a code change.
+
+## File-by-File Changes
+
+| File | Change |
+|---|---|
+| `Banderas.Domain/Exceptions/FlagDomainException.cs` | New sealed 409-mapped domain exception |
+| `Banderas.Domain/Entities/Flag.cs` | Added `using Banderas.Domain.Exceptions;`; guard clause as first statement of `SetEnabled`, `UpdateStrategy`, `UpdateName`, `Update`, `Archive` |
+| `Banderas.Tests/Domain/FlagArchivedInvariantTests.cs` | New unit-test class — 10 tests covering all 5 archived-guard paths and a happy-path baseline per method |
+No controller, service, repository, or middleware changes. No migration.
+
+## Test Notes
+
+`FlagArchivedInvariantTests` carries `[Trait("Category", "Unit")]` at the class level and on each `[Fact]`, matching the convention in `FlagTests`. Each archived-state test follows the same shape: build a flag with `FlagBuilder.Build()`, call `Archive()`, capture the second mutation in an `Action` variable, and assert with `act.Should().Throw<FlagDomainException>()`.
+
+The five happy-path tests (`*_WhenFlagIsNotArchived_Succeeds`) were added beyond the initial spec proposal of a single baseline. The reasoning: the guard clause is hand-edited into five separate methods, and a copy-paste error like `if (!IsArchived)` would slip past a single-method baseline. One short happy-path assert per method costs almost nothing and catches that class of bug.
+
+`FlagBuilder` was used as-is — no `BuildArchived()` helper added in this PR. The DX idea from the spec is left as a follow-up if archived-flag tests proliferate.
+
+## Risks and Follow-Ups
+
+- **No API-level integration test for the 409 mapping.** The middleware path (`FlagDomainException` → `409 Conflict` ProblemDetails) is verified by inspection only — `GetTitleForStatusCode` already includes the 409 case from prior work, and the catch block on `BanderasException` is unchanged. End-to-end coverage that issues a `PUT` or `DELETE` against an archived flag and asserts the response shape is deferred to a Phase 2 follow-up PR.
+- **Unarchive is explicitly out of scope.** When it lands in Phase 3, it must be an auth-gated, audited operation — not a relaxed domain rule. The terminal guard added here is the correct default until that work happens.
+- **`UpdateName` error-type shift.** Calling `UpdateName("")` on an archived flag now throws `FlagDomainException` instead of `ArgumentException`. No existing caller or test depends on the old order, but downstream consumers of the API who special-case the message text should be informed (none currently exist).
+
+## How to Test
+
+```bash
+dotnet build Banderas.sln
+dotnet test Banderas.sln --filter "FullyQualifiedName~FlagArchivedInvariantTests"
+dotnet csharpier check .
+```
+
+## Interview Lens
+
+The interesting decision here was *where* to put the rule. A pre-DDD instinct would be to add an `if (flag.IsArchived) throw ...` check in the service layer or as a FluentValidation rule on the request DTO. Both would work, and both would be wrong — they put the invariant in a place that can be bypassed. A new endpoint, a future bulk-import path, a seeding script, any of them could call `Flag.SetEnabled(...)` directly and silently mutate an archived flag. By encoding the rule on the entity, the only way to mutate an archived flag is to construct a new `Flag` — which the code path to do that does not exist.
+
+The other useful constraint was the "exception hierarchy as a communication protocol" framing. The middleware does not need to know what `FlagDomainException` means; it only needs to know `BanderasException` and trust the `StatusCode` property. That decoupling means future invariant violations are a one-line addition: `throw new FlagDomainException("…")`. No middleware change, no new catch block, no new ProblemDetails mapping.
+
+## Foundation Docs Updated
+
+- [x] `Docs/current-state.md` — Phase 2 PR #59 line in Status Summary; `FlagDomainException` and archived-terminal invariant added under Domain Layer; test counts bumped to 165 (117 unit + 48 integration); Current Focus updated for Phase 2
+- [x] `Docs/roadmap.md` — archived-terminal sub-bullet checked under Phase 2 "Strengthen `Flag` invariants"; Current Focus updated
+- [x] `Docs/architecture.md` — no architecture changes required; `FlagDomainException` is a new subclass of the existing `BanderasException` hierarchy and the middleware path was already present
+- [x] `Docs/Decisions/flag-ddd-analysis-backlog.md` — "Enforce archived state as terminal" flipped to `[X]` (PR #59)
+
+## Definition of Done — Status
+
+- [x] `FlagDomainException` exists in `Banderas.Domain/Exceptions/` and extends `BanderasException` with `StatusCode = 409`
+- [x] Guard clause is the first statement in `SetEnabled()`
+- [x] Guard clause is the first statement in `UpdateStrategy()`
+- [x] Guard clause is the first statement in `UpdateName()`
+- [x] Guard clause is the first statement in `Update()`
+- [x] Guard clause is the first statement in `Archive()`
+- [x] All 10 tests in `FlagArchivedInvariantTests.cs` pass (5 archived-guard + 5 happy-path)
+- [x] `using Banderas.Domain.Exceptions;` added to top of `Flag.cs`
+- [x] `[Trait("Category", "Unit")]` is present on the test class
+- [x] `GlobalExceptionMiddleware.GetTitleForStatusCode` includes the `409` case (verified — already present)
+- [x] `dotnet build` passes with zero warnings
+- [x] `dotnet csharpier check .` passes
+- [x] All existing tests continue to pass — no regressions (117/117 unit tests green)

--- a/Docs/Decisions/enforce-archive-state-as-terminal - PR# 59/spec.md
+++ b/Docs/Decisions/enforce-archive-state-as-terminal - PR# 59/spec.md
@@ -1,0 +1,511 @@
+# Specification: Enforce Archived State as Terminal
+
+**Document:** `Docs/Decisions/enforce-archive-state-as-terminal - PR# 59/spec.md`
+**Status:** Draft
+**Branch:** `dev`
+**PR:** #59
+**Phase:** 2 — Testing & Reliability
+**Depends on:** None
+**Author:** Jose
+**Date:** 2026-05-01
+
+---
+
+## Table of Contents
+
+- [User Story](#user-story)
+- [Background and Goals](#background-and-goals)
+- [Design Decisions](#design-decisions)
+- [Architecture Overview](#architecture-overview)
+- [Scope](#scope)
+- [Acceptance Criteria](#acceptance-criteria)
+- [File Layout](#file-layout)
+- [Technical Notes](#technical-notes)
+- [Out of Scope](#out-of-scope)
+- [Learning Opportunities](#learning-opportunities)
+- [DX / Tooling Idea](#dx--tooling-idea)
+- [Definition of Done](#definition-of-done)
+
+---
+
+## User Story
+
+> As a developer consuming the Banderas API, I want attempts to mutate an archived
+> flag to return a clear `409 Conflict` error — so I know immediately that the
+> operation was rejected by a business rule, not a server fault.
+
+---
+
+## Background and Goals
+
+`Flag` currently allows mutation after archival. Calling `SetEnabled()`,
+`Update()`, `UpdateStrategy()`, `UpdateName()`, or `Archive()` a second time on
+an already-archived flag silently succeeds — the entity changes, `UpdatedAt`
+advances, and the change is persisted. This is incorrect domain behavior.
+
+Archived is a **terminal state** in the Banderas domain. Once a flag is archived
+it is a historical record. No further mutations are meaningful or permitted. This
+rule must be enforced inside the `Flag` entity itself — not in a service, not in a
+validator, not in a controller — because the entity is the only place that owns its
+own consistency.
+
+This spec introduces `FlagDomainException` (if not already present) and adds a
+guard clause at the top of every mutation method on `Flag`.
+
+An `UnarchiveFlag` operation is **explicitly out of scope** and is deferred to
+Phase 3, where it will require an authorized principal and a dedicated, audited
+code path.
+
+---
+
+## Design Decisions
+
+### DD-1 — Single exception type with a descriptive message over per-violation exceptions
+
+**Options considered:**
+
+| Option | Pros | Cons |
+|---|---|---|
+| One `FlagDomainException` with a message | One type to maintain, one middleware case, scales to future invariants | Less granular if callers need to distinguish violations programmatically |
+| `FlagAlreadyArchivedException` + future specific types | Precise, easy to catch by type | N domain invariants = N exception types; maintenance overhead grows with the model |
+
+**Decision:** Use `FlagDomainException` with a descriptive message. The message
+is the specificity. The middleware maps one base type to 409. This is consistent
+with how `DuplicateFlagNameException` works today — a single type per violation
+category, not per field.
+
+**Rationale:** The domain model is growing. If every invariant violation gets its
+own exception type, the `Exceptions/` folder becomes noise. The message string
+carries the business-language detail callers need for error reporting.
+
+---
+
+### DD-2 — Guard clause on `Archive()` itself, not just the other mutation methods
+
+**Options considered:**
+
+| Option | Pros | Cons |
+|---|---|---|
+| Guard on all 5 methods including `Archive()` | Double-archive is caught; caller gets a clear error | Could argue double-archive is a no-op |
+| Guard on 4 mutation methods only, skip `Archive()` | Idempotent archive is sometimes desirable | Hides a likely caller bug; inconsistent with "archived is immutable" |
+
+**Decision:** Guard on all 5 methods including `Archive()`. If a caller is
+trying to archive an already-archived flag, that is a bug in the caller, not a
+legitimate operation. Returning an error surfaces the bug. Making it a silent
+no-op hides it.
+
+---
+
+### DD-3 — Domain throws, middleware catches — no intermediary handling
+
+**Options considered:**
+
+| Option | Pros | Cons |
+|---|---|---|
+| Domain throws → middleware catches (current pattern) | Consistent with all other domain exceptions; zero new coupling | None — this is the established pattern |
+| Application layer catches and maps to a result type | More explicit flow control | Requires Application to know about EF/HTTP; violates layer rules |
+| Controller try/catch | Simple | Returns to the per-controller error handling anti-pattern we removed in PR #36 |
+
+**Decision:** Domain throws `FlagDomainException`. It extends `BanderasException`.
+`GlobalExceptionMiddleware` catches it via the existing `BanderasException` catch
+block and writes a `409 ProblemDetails` response automatically. No new middleware
+code required.
+
+---
+
+### DD-4 — Archived state is strictly terminal now; unarchive is a Phase 3 feature
+
+**Options considered:**
+
+| Option | Pros | Cons |
+|---|---|---|
+| Strictly terminal now, unarchive later | Simple, correct default; no premature auth logic | Requires a deliberate Phase 3 PR to relax |
+| Leave open now "just in case" | Fewer future changes | Permits invalid state today; auth concern bleeds into domain prematurely |
+
+**Decision:** Strictly terminal. Document the unarchive path in the roadmap and
+DDD backlog for Phase 3. It must be an auth-gated, audited operation when it
+arrives — not a relaxed domain rule.
+
+---
+
+## Architecture Overview
+
+This change is entirely within the **Domain layer**. It does not cross any
+layer boundary.
+
+```
+Banderas.Domain
+└── Exceptions/
+│   └── FlagDomainException.cs    ← NEW (or verify already exists)
+└── Entities/
+    └── Flag.cs                   ← MODIFY: add guard clause to 5 methods
+```
+
+The `GlobalExceptionMiddleware` in `Banderas.Api` already catches
+`BanderasException` via the base class. Because `FlagDomainException` extends
+`BanderasException` with `StatusCode = 409`, no middleware change is needed.
+
+**Dependency rule check:** Domain has no dependency on Application, Infrastructure,
+or Api. This change adds nothing new. ✅
+
+---
+
+## Scope
+
+| # | Action | File |
+|---|---|---|
+| 1 | Create (or verify) `FlagDomainException` | `Banderas.Domain/Exceptions/FlagDomainException.cs` |
+| 2 | Add guard clause to `SetEnabled()` | `Banderas.Domain/Entities/Flag.cs` |
+| 3 | Add guard clause to `UpdateStrategy()` | `Banderas.Domain/Entities/Flag.cs` |
+| 4 | Add guard clause to `UpdateName()` | `Banderas.Domain/Entities/Flag.cs` |
+| 5 | Add guard clause to `Update()` | `Banderas.Domain/Entities/Flag.cs` |
+| 6 | Add guard clause to `Archive()` | `Banderas.Domain/Entities/Flag.cs` |
+| 7 | Unit tests for all 5 guard clauses | `Banderas.Tests/Domain/FlagArchivedInvariantTests.cs` |
+| 8 | Verify `GlobalExceptionMiddleware` 409 path | `Banderas.Api/Middleware/GlobalExceptionMiddleware.cs` |
+
+No controller changes. No service changes. No repository changes. No migration.
+
+---
+
+## Acceptance Criteria
+
+### AC-1: `FlagDomainException` exists and extends `BanderasException`
+
+**File:** `Banderas.Domain/Exceptions/FlagDomainException.cs`
+
+If the file already exists, verify it matches this shape. If it does not exist,
+create it.
+
+```csharp
+using Microsoft.AspNetCore.Http;
+
+namespace Banderas.Domain.Exceptions;
+
+/// <summary>
+/// Thrown when an operation violates a domain invariant on Flag.
+/// Maps to HTTP 409 Conflict.
+/// </summary>
+public sealed class FlagDomainException : BanderasException
+{
+    public FlagDomainException(string message)
+        : base(message, StatusCodes.Status409Conflict) { }
+}
+```
+
+**Rules:**
+- Must extend `BanderasException` — this is what connects it to the middleware.
+- `StatusCode` is `409`. The middleware derives the HTTP status from `ex.StatusCode`.
+- `sealed` — not intended for subclassing.
+- No ASP.NET Core references except `StatusCodes` — consistent with existing
+  exceptions in the hierarchy.
+
+---
+
+### AC-2: Guard clause added to all five mutation methods on `Flag`
+
+**File:** `Banderas.Domain/Entities/Flag.cs`
+
+Add the following guard clause as the **first statement** inside each of these
+five methods: `SetEnabled()`, `UpdateStrategy()`, `UpdateName()`, `Update()`,
+`Archive()`.
+
+```csharp
+if (IsArchived)
+    throw new FlagDomainException($"Flag '{Name}' is archived and cannot be modified.");
+```
+
+The complete updated signatures after modification:
+
+```csharp
+public void SetEnabled(bool enabled)
+{
+    if (IsArchived)
+        throw new FlagDomainException($"Flag '{Name}' is archived and cannot be modified.");
+
+    IsEnabled = enabled;
+    UpdatedAt = DateTime.UtcNow;
+}
+
+public void UpdateStrategy(RolloutStrategy strategyType, string? strategyConfig)
+{
+    if (IsArchived)
+        throw new FlagDomainException($"Flag '{Name}' is archived and cannot be modified.");
+
+    StrategyType = strategyType;
+    StrategyConfig = strategyConfig ?? "{}";
+    UpdatedAt = DateTime.UtcNow;
+}
+
+public void UpdateName(string name)
+{
+    if (IsArchived)
+        throw new FlagDomainException($"Flag '{Name}' is archived and cannot be modified.");
+
+    if (string.IsNullOrWhiteSpace(name))
+        throw new ArgumentException("Name cannot be empty.", nameof(name));
+
+    Name = name;
+    UpdatedAt = DateTime.UtcNow;
+}
+
+public void Update(bool isEnabled, RolloutStrategy strategyType, string? strategyConfig)
+{
+    if (IsArchived)
+        throw new FlagDomainException($"Flag '{Name}' is archived and cannot be modified.");
+
+    IsEnabled = isEnabled;
+    StrategyType = strategyType;
+    StrategyConfig = strategyConfig ?? "{}";
+    UpdatedAt = DateTime.UtcNow;
+}
+
+public void Archive()
+{
+    if (IsArchived)
+        throw new FlagDomainException($"Flag '{Name}' is archived and cannot be modified.");
+
+    IsArchived = true;
+    ArchivedAt = DateTime.UtcNow;
+    UpdatedAt = DateTime.UtcNow;
+}
+```
+
+**Rules:**
+- Guard clause must be the **first statement** in each method — before any
+  argument validation, before any state mutation.
+- The exception message must include the flag's `Name` — callers need to know
+  which flag was rejected.
+- Use `FlagDomainException` — not `InvalidOperationException`, not
+  `ArgumentException`, not a raw `Exception`.
+- Do not change the method signatures. Do not change any logic below the guard.
+- `using Banderas.Domain.Exceptions;` must be added to the top of `Flag.cs`
+  (it is not currently present).
+- **Behavior shift on `UpdateName`:** the archived-guard runs *before* the
+  existing whitespace-name guard. After this change, calling `UpdateName("")`
+  on an archived flag throws `FlagDomainException` instead of `ArgumentException`.
+  No existing caller or test depends on the previous order, but this is an
+  intentional, observable change.
+
+---
+
+### AC-3: Unit tests for all guard clauses
+
+**File:** `Banderas.Tests/Domain/FlagArchivedInvariantTests.cs`
+
+Create a new test class. Use `FlagBuilder` (already present in
+`Banderas.Tests/Helpers/FlagBuilder.cs`) to construct flags.
+
+The test class must carry `[Trait("Category", "Unit")]` at the class level.
+
+**Tests to implement:**
+
+**AI-1 — `SetEnabled` on an archived flag throws `FlagDomainException`**
+```
+SetEnabled_WhenFlagIsArchived_ThrowsFlagDomainException
+```
+Build a flag. Call `Archive()`. Call `SetEnabled(true)`.
+Assert `FlagDomainException` is thrown.
+
+**AI-2 — `UpdateStrategy` on an archived flag throws `FlagDomainException`**
+```
+UpdateStrategy_WhenFlagIsArchived_ThrowsFlagDomainException
+```
+Build a flag. Call `Archive()`. Call `UpdateStrategy(RolloutStrategy.None, null)`.
+Assert `FlagDomainException` is thrown.
+
+**AI-3 — `UpdateName` on an archived flag throws `FlagDomainException`**
+```
+UpdateName_WhenFlagIsArchived_ThrowsFlagDomainException
+```
+Build a flag. Call `Archive()`. Call `UpdateName("new-name")`.
+Assert `FlagDomainException` is thrown.
+
+**AI-4 — `Update` on an archived flag throws `FlagDomainException`**
+```
+Update_WhenFlagIsArchived_ThrowsFlagDomainException
+```
+Build a flag. Call `Archive()`. Call `Update(false, RolloutStrategy.None, null)`.
+Assert `FlagDomainException` is thrown.
+
+**AI-5 — `Archive` called twice throws `FlagDomainException`**
+```
+Archive_WhenFlagIsAlreadyArchived_ThrowsFlagDomainException
+```
+Build a flag. Call `Archive()`. Call `Archive()` again.
+Assert `FlagDomainException` is thrown.
+
+**AI-6 — Mutations on a non-archived flag succeed (baseline, one per method)**
+
+Add a happy-path assert per guarded method to catch copy-paste errors in the
+guard (e.g. `if (!IsArchived)`):
+
+```
+SetEnabled_WhenFlagIsNotArchived_Succeeds
+UpdateStrategy_WhenFlagIsNotArchived_Succeeds
+UpdateName_WhenFlagIsNotArchived_Succeeds
+Update_WhenFlagIsNotArchived_Succeeds
+Archive_WhenFlagIsNotArchived_Succeeds
+```
+
+Each builds a non-archived flag, invokes the method, and asserts no exception
+plus the expected state mutation occurred (e.g. `IsEnabled == true`,
+`IsArchived == true`, etc.). One-liner asserts are sufficient.
+
+**Test structure example:**
+
+```csharp
+[Fact]
+[Trait("Category", "Unit")]
+public void SetEnabled_WhenFlagIsArchived_ThrowsFlagDomainException()
+{
+    // Arrange
+    var flag = FlagBuilder.Build();
+    flag.Archive();
+
+    // Act
+    var act = () => flag.SetEnabled(true);
+
+    // Assert
+    act.Should().Throw<FlagDomainException>();
+}
+```
+
+---
+
+### AC-4: `GlobalExceptionMiddleware` — verify 409 path
+
+**File:** `Banderas.Api/Middleware/GlobalExceptionMiddleware.cs`
+
+No code change required — verified present. The `BanderasException` catch block
+exists (line 39) and `GetTitleForStatusCode` already includes the `409` case
+(line 111):
+
+```csharp
+private static string GetTitleForStatusCode(int statusCode) =>
+    statusCode switch
+    {
+        StatusCodes.Status400BadRequest => "Bad Request",
+        StatusCodes.Status404NotFound   => "Not Found",
+        StatusCodes.Status409Conflict   => "Conflict",
+        _                               => "An error occurred",
+    };
+```
+
+This AC is satisfied by the current state of the file. No work item.
+
+---
+
+## File Layout
+
+```
+Banderas.Domain/
+└── Exceptions/
+│   └── FlagDomainException.cs         ← CREATE (or verify)
+└── Entities/
+    └── Flag.cs                         ← MODIFY
+
+Banderas.Tests/
+└── Domain/
+    └── FlagArchivedInvariantTests.cs   ← CREATE
+```
+
+No other files are created or modified.
+
+---
+
+## Technical Notes
+
+- `FlagDomainException` needs a `FrameworkReference` to
+  `Microsoft.AspNetCore.App` to use `StatusCodes` — this reference is already
+  present on `Banderas.Domain` from prior work (`FlagNotFoundException` uses it).
+  No package change required.
+- `FlagBuilder` is in `Banderas.Tests/Helpers/FlagBuilder.cs`. Use it as-is.
+  If `FlagBuilder` does not expose a way to produce an already-archived flag
+  directly, call `Archive()` on the built flag inside the test — do not add
+  an `isArchived` parameter to `FlagBuilder` as part of this PR.
+- `Flag.cs` currently has only `using Banderas.Domain.Enums;`. This PR **must**
+  add `using Banderas.Domain.Exceptions;` at the top of the file — same-assembly
+  namespaces are not implicitly imported, and there is no `GlobalUsings` file in
+  this project.
+- The `xmin`/`Version` concurrency property added in the previous PR must remain
+  untouched. The guard clauses are inserted above existing mutation logic only.
+- **No API-level integration test** asserts the end-to-end `409` response for
+  an archived-flag mutation in this PR. Middleware mapping
+  (`FlagDomainException` → `409 Conflict`) is verified by inspection only here;
+  HTTP-level coverage is deferred to the Phase 2 follow-up PR listed in
+  *Out of Scope*.
+
+---
+
+## Out of Scope
+
+| Item | Deferred to |
+|---|---|
+| `UnarchiveFlag` operation | Phase 3 — requires auth-gated, audited code path |
+| Authorization policy for who may archive a flag | Phase 3 — JWT + RBAC |
+| API-level integration test asserting `409` response from a `PUT` or `DELETE` on an archived flag | Phase 2 follow-up PR — `refactor/flag-domain-invariants` integration coverage |
+| `IsSeeded` removal from `Flag` | Next item in DDD backlog — separate PR |
+| Any change to `FeatureFlagContext`, `FeatureEvaluationContext`, or evaluation logic | Out of scope for this refactor |
+
+---
+
+## Learning Opportunities
+
+**1. Make Illegal States Unrepresentable (MISR)**
+This is a core DDD principle. Instead of checking "is the flag archived?" in
+multiple places across the service and controller layers, we encode the rule
+in the type itself. An archived `Flag` object physically cannot be mutated
+without throwing. The compiler and runtime together enforce the business rule —
+not a validator somewhere downstream that might be forgotten.
+
+**2. Guard clauses as domain invariant enforcement**
+Guard clauses at the top of methods are the idiomatic C# way to enforce
+preconditions. The pattern is: check the condition first, throw if violated,
+then proceed with the happy path. This keeps the method's intent visible and
+the happy path unindented. In DDD, these guard clauses are the domain's
+"immune system" — they prevent the model from entering an invalid state.
+
+**3. Exception hierarchy as a communication protocol**
+`FlagDomainException` extending `BanderasException` is not just inheritance for
+reuse — it is a communication protocol between the domain and the middleware.
+The middleware only needs to know `BanderasException`; it does not need to know
+every specific violation type. Adding a new domain rule violation in the future
+requires only a new `throw new FlagDomainException(...)` — the middleware
+already handles it.
+
+---
+
+## DX / Tooling Idea
+
+Add an `IsArchived` assertion helper to `FlagBuilder` — not a constructor
+parameter, but a fluent method:
+
+```csharp
+public static Flag BuildArchived() =>
+    Build().TapArchive();
+```
+
+where `TapArchive()` is an internal test helper extension that calls
+`flag.Archive()` and returns the flag. This makes archived-flag tests a
+one-liner in setup and signals clearly to the reader that the test intent
+is "an archived flag." Defer to after this PR if `FlagBuilder` needs broader
+changes.
+
+---
+
+## Definition of Done
+
+- [ ] `FlagDomainException` exists in `Banderas.Domain/Exceptions/` and extends
+      `BanderasException` with `StatusCode = 409`
+- [ ] Guard clause is the first statement in `SetEnabled()`
+- [ ] Guard clause is the first statement in `UpdateStrategy()`
+- [ ] Guard clause is the first statement in `UpdateName()`
+- [ ] Guard clause is the first statement in `Update()`
+- [ ] Guard clause is the first statement in `Archive()`
+- [ ] All 10 tests in `FlagArchivedInvariantTests.cs` pass (5 archived-guard + 5 happy-path)
+- [ ] `using Banderas.Domain.Exceptions;` added to top of `Flag.cs`
+- [ ] `[Trait("Category", "Unit")]` is present on the test class
+- [ ] `GlobalExceptionMiddleware.GetTitleForStatusCode` includes the `409` case
+- [ ] `dotnet build` passes with zero warnings
+- [ ] `dotnet csharpier check .` passes
+- [ ] All existing tests continue to pass — no regressions

--- a/Docs/Decisions/flag-ddd-analysis-backlog.md
+++ b/Docs/Decisions/flag-ddd-analysis-backlog.md
@@ -74,8 +74,8 @@ public class FlagEnvironmentConfig
 > Not yet scoped, specced, or assigned to a PR.  
 > Sequence is approximate — some items have dependencies.
 
-- [ ] **Introduce `FlagDomainException`** — dedicated domain exception type; thrown by domain invariant violations; lives in `Banderas.Domain`
-- [ ] **Enforce archived state as terminal** — guard clause at top of `Archive()`, `SetEnabled()`, `UpdateStrategy()`, `Update()`, and `UpdateName()`; throw `FlagDomainException` if already archived
+- [X] **Introduce `FlagDomainException`** — dedicated domain exception type; thrown by domain invariant violations; lives in `Banderas.Domain`
+- [X] **Enforce archived state as terminal** — guard clause at top of `Archive()`, `SetEnabled()`, `UpdateStrategy()`, `Update()`, and `UpdateName()`; throw `FlagDomainException` if already archived (PR #59)
 - [ ] **Remove `IsSeeded` from `Flag`** — move to infrastructure seeding concern; its presence on the domain entity is a boundary violation
 - [ ] **Consolidate `SetEnabled()` + `UpdateStrategy()` + `Update()`** — separate by concern not field; name changes (`UpdateName()`) are a distinct operation; rollout config changes are one operation
 - [ ] **Convert `StrategyConfig` from raw `string` to typed Value Objects** — one Value Object per strategy type (e.g. `PercentageConfig`, `RoleBasedConfig`); invalid config caught at construction

--- a/Docs/current-state.md
+++ b/Docs/current-state.md
@@ -43,11 +43,13 @@
 
 **Phase 1.5 — Azure Foundation + AI Integration: ✅ Architecture Review Complete**
 
+**Phase 2 — Enforce Archived State as Terminal (PR #59): ✅ Complete**
+
 **Gate Decision:** GO WITH CONDITIONS — AI response validation condition closed
 
 Audit report: `Docs/architecture-review-phase1-report.md`
 
-155/155 tests passing (107 unit + 48 integration).
+165/165 tests passing (117 unit + 48 integration).
 
 ---
 
@@ -66,7 +68,11 @@ Audit report: `Docs/architecture-review-phase1-report.md`
 - `IRolloutStrategy` interface — includes `StrategyType` for registry dispatch
 - `IBanderasRepository` interface — async signatures with `CancellationToken`
 - Domain exceptions: `FlagNotFoundException`, `DuplicateFlagNameException`,
-  `BanderasValidationException`
+  `BanderasValidationException`, `FlagDomainException` (409 Conflict — generic
+  domain invariant violation type)
+- `Flag` archived state is terminal — guard clause as the first statement of
+  `SetEnabled`, `UpdateStrategy`, `UpdateName`, `Update`, and `Archive`; throws
+  `FlagDomainException` if `IsArchived` is `true`
 
 ### Application Layer
 
@@ -143,12 +149,13 @@ Audit report: `Docs/architecture-review-phase1-report.md`
 
 ### Tests
 
-- 107 unit tests — strategies, evaluator, validators, logging behavior,
-  prompt sanitization (21), service analysis (5)
+- 117 unit tests — strategies, evaluator, validators, logging behavior,
+  prompt sanitization (21), service analysis (5), `Flag` archived-terminal
+  invariants (10)
 - 48 integration tests — all endpoints including `POST /api/flags/health`,
   missing-Azure-OpenAI startup resilience, AI-unavailable 503 behavior, and
   semantic AI response validation
-- 155/155 passing
+- 165/165 passing
 - `AssemblyInfo.cs` — `InternalsVisibleTo("Banderas.Tests")`
 - `BanderasServiceLoggingTests` — `NullPromptSanitizer` + `NullAiFlagAnalyzer`
   hand-written stubs (consistent with existing `NullTelemetryService` pattern)
@@ -199,13 +206,17 @@ undocumented status values before any `200 OK` response can leave the AI boundar
 
 ## 🎯 Current Focus
 
-**Phase 2 Prep — Remaining Gate Conditions**
+**Phase 2 — Testing & Reliability**
 
 ### Immediate Next Tasks
 
-1. Strengthen `Flag` invariants and direct domain tests before adding new input surfaces
-2. Decide whether GET query environment validation should move to the HTTP boundary
+1. Decide whether GET query environment validation should move to the HTTP boundary
    or remain documented as service-level validation
+2. API-level integration coverage for the archived-flag `409` mapping (deferred from
+   PR #59 — `FlagDomainException` → `409 Conflict` is verified by inspection only)
+3. Continue working through the `Flag` DDD analysis backlog
+   (`Docs/Decisions/flag-ddd-analysis-backlog.md`) — next item: remove `IsSeeded`
+   from the domain entity
 
 ---
 

--- a/Docs/roadmap.md
+++ b/Docs/roadmap.md
@@ -168,6 +168,11 @@ Every phase of this roadmap builds toward that demo.
 * [x] Formally keep `FeatureEvaluationContext` as the evaluation value-object
       exception to the DTO-only service-boundary convention
 * [ ] Strengthen `Flag` invariants and direct domain tests before adding new input surfaces
+  * [x] Enforce archived state as terminal — `FlagDomainException` guard on all
+        five `Flag` mutation methods (PR #59)
+  * [ ] Remove `IsSeeded` from the `Flag` domain entity
+  * [ ] Convert `StrategyConfig` from raw `string` to typed Value Objects
+  * [ ] Enforce config/strategy type consistency inside `Flag`
 * [ ] Contract tests for API responses
 * [ ] Handle invalid strategy configurations gracefully
 * [ ] Test environment-specific behavior edge cases
@@ -247,13 +252,16 @@ Every phase of this roadmap builds toward that demo.
 
 ## 🎯 Current Focus
 
-**Phase 2 Prep — Gate: GO WITH CONDITIONS**
+**Phase 2 — Testing & Reliability**
 
-1. Strengthen direct domain invariants and tests
-2. Decide whether GET query environment validation should move earlier or remain
+1. Continue strengthening `Flag` domain invariants — next backlog items:
+   remove `IsSeeded` from the domain entity, then typed `StrategyConfig` Value Objects
+2. API-level integration coverage for archived-flag `409` mapping (deferred from PR #59)
+3. Decide whether GET query environment validation should move earlier or remain
    explicitly documented as service-level validation
 
-**Phase 1.5 closed with GO WITH CONDITIONS; AI output-contract condition is closed.**
+**Phase 1.5 closed with GO WITH CONDITIONS; AI output-contract condition is closed.
+Phase 2 first invariant landed in PR #59 (archived state is terminal).**
 
 ---
 


### PR DESCRIPTION
## Summary

  `Flag` now treats archival as a terminal state. Every mutation method on the entity
  (`SetEnabled`, `UpdateStrategy`, `UpdateName`, `Update`, `Archive`) carries a guard
  clause as its first statement: if `IsArchived` is `true`, the method throws a new
  `FlagDomainException` whose message names the flag. The exception extends
  `BanderasException` with `StatusCode = 409`, so the existing `GlobalExceptionMiddleware`
  maps it to a `409 Conflict` ProblemDetails response with no middleware change. The
  change is contained entirely within the Domain layer — no controllers, services,
  repositories, or migrations were touched.

  ## Changes in this PR

  - **Domain** — new `FlagDomainException` (sealed, `BanderasException`-derived, 409); guard clause added as the first statement of all five `Flag` mutation methods
  - **Tests** — new `FlagArchivedInvariantTests` (10 tests: 5 archived-guard + 5 happy-path baselines)
  - **Docs** — `current-state.md`, `roadmap.md`, and the `Flag` DDD backlog updated; spec + implementation notes added under `Docs/Decisions/enforce-archive-state-as-terminal - PR# 59/`

  ## Spec

  `Docs/Decisions/enforce-archive-state-as-terminal - PR# 59/spec.md`

  ## Implementation Notes

  `Docs/Decisions/enforce-archive-state-as-terminal - PR# 59/implementation-notes.md`

  ## Definition of Done

  - [x] `FlagDomainException` exists in `Banderas.Domain/Exceptions/` and extends `BanderasException` with `StatusCode = 409`
  - [x] Guard clause is the first statement in `SetEnabled()`
  (`SetEnabled`, `UpdateStrategy`, `UpdateName`, `Update`, `Archive`) carries a guard
  clause as its first statement: if `IsArchived` is `true`, the method throws a new
  `FlagDomainException` whose message names the flag. The exception extends
  `BanderasException` with `StatusCode = 409`, so the existing `GlobalExceptionMiddleware`
  maps it to a `409 Conflict` ProblemDetails response with no middleware change. The
  change is contained entirely within the Domain layer — no controllers, services,
  repositories, or migrations were touched.

  ## Changes in this PR

  - **Domain** — new `FlagDomainException` (sealed, `BanderasException`-derived, 409); guard clause added as the first
  statement of all five `Flag` mutation methods
  - **Tests** — new `FlagArchivedInvariantTests` (10 tests: 5 archived-guard + 5 happy-path baselines)
  - **Docs** — `current-state.md`, `roadmap.md`, and the `Flag` DDD backlog updated; spec + implementation notes added
  under `Docs/Decisions/enforce-archive-state-as-terminal - PR# 59/`