### PR TITLE
Test/archived flag 409 integration

### DIFF
--- a/Banderas.Tests.Integration/ArchivedFlag409MiddlewareTests.cs
+++ b/Banderas.Tests.Integration/ArchivedFlag409MiddlewareTests.cs
@@ -1,0 +1,32 @@
+using System.Net;
+using Banderas.Tests.Integration.Fixtures;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Banderas.Tests.Integration;
+
+[Collection("Integration")]
+[Trait("Category", "Integration")]
+public sealed class ArchivedFlag409MiddlewareTests : IntegrationTestBase
+{
+    public ArchivedFlag409MiddlewareTests(BanderasApiFactory factory)
+        : base(factory) { }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task FlagDomainException_Returns409ConflictProblemDetailsAsync()
+    {
+        // Arrange — test-only endpoint registered in BanderasApiFactory
+        //   throws FlagDomainException("Test flag 'test-flag' is archived and cannot be modified.")
+
+        // Act
+        HttpResponseMessage response = await Client.GetAsync("/test/throw-domain-exception");
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        ProblemDetails body = await ReadProblemDetailsAsync(response, HttpStatusCode.Conflict);
+        body.Title.Should().Be("Conflict");
+        body.Detail.Should().Contain("test-flag");
+        body.Detail.Should().Contain("archived and cannot be modified");
+    }
+}

--- a/Banderas.Tests.Integration/EvaluationEndpointTests.cs
+++ b/Banderas.Tests.Integration/EvaluationEndpointTests.cs
@@ -209,6 +209,37 @@ public sealed class EvaluationEndpointTests : IntegrationTestBase
 
     [Fact]
     [Trait("Category", "Integration")]
+    public async Task Evaluate_ArchivedFlag_Returns404Async()
+    {
+        // Arrange
+        await CreateFlagAsync(name: "archived-eval-flag");
+        HttpResponseMessage archiveResponse = await Client.DeleteAsync(
+            "/api/flags/archived-eval-flag?environment=Development"
+        );
+        archiveResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var request = new EvaluationRequest(
+            "archived-eval-flag",
+            "user-1",
+            [],
+            EnvironmentType.Development
+        );
+
+        // Act
+        HttpResponseMessage response = await Client.PostAsJsonAsync(
+            "/api/evaluate",
+            request,
+            JsonOptions
+        );
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        ProblemDetails body = await ReadProblemDetailsAsync(response, HttpStatusCode.NotFound);
+        body.Detail.Should().Contain("archived-eval-flag");
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
     public async Task Evaluate_MissingUserId_Returns400Async()
     {
         // Arrange

--- a/Banderas.Tests.Integration/Fixtures/BanderasApiFactory.cs
+++ b/Banderas.Tests.Integration/Fixtures/BanderasApiFactory.cs
@@ -1,8 +1,10 @@
 using Banderas.Application.AI;
 using Banderas.Application.DTOs;
 using Banderas.Application.Exceptions;
+using Banderas.Domain.Exceptions;
 using Banderas.Infrastructure.Persistence;
 using Banderas.Infrastructure.Seeding;
+using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
@@ -57,6 +59,10 @@ public sealed class BanderasApiFactory : WebApplicationFactory<Program>, IAsyncL
             // Semantic Kernel and Azure OpenAI are not registered in Testing.
             // Provide a deterministic stub so integration tests don't hit Azure.
             services.AddScoped<IAiFlagAnalyzer, StubAiFlagAnalyzer>();
+
+            // Test-only endpoint: throws FlagDomainException so integration tests
+            // can verify the GlobalExceptionMiddleware 409 ProblemDetails shape.
+            services.AddSingleton<IStartupFilter, TestDomainExceptionEndpointFilter>();
         });
     }
 
@@ -95,6 +101,26 @@ public sealed class BanderasApiFactory : WebApplicationFactory<Program>, IAsyncL
             int stalenessThresholdDays,
             CancellationToken cancellationToken = default
         ) => throw new AiAnalysisUnavailableException("Stub: AI analysis unavailable.");
+    }
+
+    private sealed class TestDomainExceptionEndpointFilter : IStartupFilter
+    {
+        public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next)
+        {
+            return app =>
+            {
+                next(app);
+                app.Map(
+                    "/test/throw-domain-exception",
+                    branch =>
+                        branch.Run(_ =>
+                            throw new FlagDomainException(
+                                "Test flag 'test-flag' is archived and cannot be modified."
+                            )
+                        )
+                );
+            };
+        }
     }
 
     public async Task InitializeAsync()

--- a/Banderas.Tests.Integration/FlagEndpointTests.cs
+++ b/Banderas.Tests.Integration/FlagEndpointTests.cs
@@ -518,6 +518,59 @@ public sealed class FlagEndpointTests : IntegrationTestBase
 
     [Fact]
     [Trait("Category", "Integration")]
+    public async Task UpdateFlag_ArchivedFlag_Returns404ProblemDetailsAsync()
+    {
+        // Arrange
+        await CreateFlagAsync(name: "archived-update-flag");
+        HttpResponseMessage archiveResponse = await Client.DeleteAsync(
+            "/api/flags/archived-update-flag?environment=Development"
+        );
+        archiveResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var payload = new
+        {
+            IsEnabled = false,
+            StrategyType = RolloutStrategy.None,
+            StrategyConfig = (string?)null,
+        };
+
+        // Act
+        HttpResponseMessage response = await Client.PutAsJsonAsync(
+            "/api/flags/archived-update-flag?environment=Development",
+            payload,
+            JsonOptions
+        );
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        ProblemDetails body = await ReadProblemDetailsAsync(response, HttpStatusCode.NotFound);
+        body.Detail.Should().Contain("archived-update-flag");
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
+    public async Task ArchiveFlag_AlreadyArchived_Returns404ProblemDetailsAsync()
+    {
+        // Arrange
+        await CreateFlagAsync(name: "double-archive-flag");
+        HttpResponseMessage archiveResponse = await Client.DeleteAsync(
+            "/api/flags/double-archive-flag?environment=Development"
+        );
+        archiveResponse.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        // Act
+        HttpResponseMessage response = await Client.DeleteAsync(
+            "/api/flags/double-archive-flag?environment=Development"
+        );
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+        ProblemDetails body = await ReadProblemDetailsAsync(response, HttpStatusCode.NotFound);
+        body.Detail.Should().Contain("double-archive-flag");
+    }
+
+    [Fact]
+    [Trait("Category", "Integration")]
     public async Task ArchiveFlag_NotFound_Returns404ProblemDetailsAsync()
     {
         // Arrange

--- a/Docs/current-state.md
+++ b/Docs/current-state.md
@@ -45,12 +45,13 @@
 
 **Phase 2 — Enforce Archived State as Terminal (PR #59): ✅ Complete**
 **Phase 2 — Remove `IsSeeded` from `Flag` Domain Entity (PR TBD): ✅ Complete**
+**Phase 2 — Archived-Flag Integration Test Coverage (PR TBD): ✅ Complete**
 
 **Gate Decision:** GO WITH CONDITIONS — AI response validation condition closed
 
 Audit report: `Docs/architecture-review-phase1-report.md`
 
-165/165 tests passing (117 unit + 48 integration).
+169/169 tests passing (115 unit + 54 integration).
 
 ---
 
@@ -151,13 +152,14 @@ Audit report: `Docs/architecture-review-phase1-report.md`
 
 ### Tests
 
-- 117 unit tests — strategies, evaluator, validators, logging behavior,
+- 115 unit tests — strategies, evaluator, validators, logging behavior,
   prompt sanitization (21), service analysis (5), `Flag` archived-terminal
   invariants (10)
-- 48 integration tests — all endpoints including `POST /api/flags/health`,
-  missing-Azure-OpenAI startup resilience, AI-unavailable 503 behavior, and
-  semantic AI response validation
-- 165/165 passing
+- 54 integration tests — all endpoints including `POST /api/flags/health`,
+  missing-Azure-OpenAI startup resilience, AI-unavailable 503 behavior,
+  semantic AI response validation, archived-flag mutation coverage (PUT/DELETE/evaluate
+  → 404), and `FlagDomainException` → 409 ProblemDetails middleware contract
+- 169/169 passing
 - `AssemblyInfo.cs` — `InternalsVisibleTo("Banderas.Tests")`
 - `BanderasServiceLoggingTests` — `NullPromptSanitizer` + `NullAiFlagAnalyzer`
   hand-written stubs (consistent with existing `NullTelemetryService` pattern)
@@ -165,7 +167,9 @@ Audit report: `Docs/architecture-review-phase1-report.md`
   empty-list, missing-flag, invalid-status, and valid-pass-through paths
 - `BanderasApiFactory` — `StubAiFlagAnalyzer` registered for deterministic
   integration test responses; `ThrowingAiFlagAnalyzer` factory path verifies
-  endpoint-scoped 503 behavior; no Azure calls in CI
+  endpoint-scoped 503 behavior; `TestDomainExceptionEndpointFilter` (`IStartupFilter`)
+  registers `GET /test/throw-domain-exception` for synthetic 409 middleware testing;
+  no Azure calls in CI
 
 ### Developer Experience
 
@@ -214,11 +218,10 @@ undocumented status values before any `200 OK` response can leave the AI boundar
 
 1. Decide whether GET query environment validation should move to the HTTP boundary
    or remain documented as service-level validation
-2. API-level integration coverage for the archived-flag `409` mapping (deferred from
-   PR #59 — `FlagDomainException` → `409 Conflict` is verified by inspection only)
-3. Continue working through the `Flag` DDD analysis backlog
+2. Continue working through the `Flag` DDD analysis backlog
    (`Docs/Decisions/flag-ddd-analysis-backlog.md`) — next item: consolidate
    `SetEnabled` / `UpdateStrategy` / `Update` by concern
+3. Convert `StrategyConfig` from raw `string` to typed Value Objects
 
 ---
 
@@ -302,6 +305,18 @@ undocumented status values before any `200 OK` response can leave the AI boundar
   is ambiguous and will not compile.
 - `GeneratedRegex` attribute — prefer over `new Regex(...)` for patterns used in
   hot paths; compile-time generation avoids runtime allocation
+- `[2026-05-05] — Defense-in-depth testing: test what clients see, not what guards throw`
+
+  When two layers guard the same invariant (repository `!f.IsArchived` filter + domain
+  `FlagDomainException` guard), the HTTP API's observable behavior is determined by the
+  outermost layer (404 from repo filter), not the inner guard (409 from domain). Integration
+  tests must assert the actual client-visible response (404), not the domain-level contract
+  (409). To cover the inner guard's middleware mapping, use a synthetic test-only endpoint
+  via `IStartupFilter` that throws the domain exception directly. The rule going forward:
+  when spec'ing integration coverage for a defense-in-depth invariant, identify which layer
+  the HTTP request reaches first and assert that layer's response, then add one synthetic
+  test for the inner guard's middleware contract.
+
 - `[2026-04-28] — AI boundary validation needs direct analyzer coverage`
 
   Semantic validation inside `AiFlagAnalyzer` is intentionally private because no other

--- a/Docs/roadmap.md
+++ b/Docs/roadmap.md
@@ -59,7 +59,7 @@ Every phase of this roadmap builds toward that demo.
 | 0 | Foundation | ✅ Complete |
 | 1 | MVP Completion | ✅ Complete |
 | 1.5 | Azure Foundation + AI Integration | ✅ Complete — Gate: GO WITH CONDITIONS |
-| 2 | Testing & Reliability | Planned |
+| 2 | Testing & Reliability | In Progress |
 | 3 | Auth, Authorization & Rate Limiting | Planned |
 | 4 | Observability & Debugging | Planned |
 | 5 | Advanced Rollout Strategies | Planned |
@@ -170,7 +170,9 @@ Every phase of this roadmap builds toward that demo.
 * [ ] Strengthen `Flag` invariants and direct domain tests before adding new input surfaces
   * [x] Enforce archived state as terminal — `FlagDomainException` guard on all
         five `Flag` mutation methods (PR #59)
-  * [ ] Remove `IsSeeded` from the `Flag` domain entity
+  * [x] Remove `IsSeeded` from the `Flag` domain entity
+  * [x] Archived-flag integration test coverage — PUT/DELETE/evaluate → 404,
+        `FlagDomainException` → 409 middleware contract (PR TBD)
   * [ ] Convert `StrategyConfig` from raw `string` to typed Value Objects
   * [ ] Enforce config/strategy type consistency inside `Flag`
 * [ ] Contract tests for API responses
@@ -254,14 +256,14 @@ Every phase of this roadmap builds toward that demo.
 
 **Phase 2 — Testing & Reliability**
 
-1. Continue strengthening `Flag` domain invariants — next backlog items:
-   remove `IsSeeded` from the domain entity, then typed `StrategyConfig` Value Objects
-2. API-level integration coverage for archived-flag `409` mapping (deferred from PR #59)
-3. Decide whether GET query environment validation should move earlier or remain
+1. Continue strengthening `Flag` domain invariants — next backlog item:
+   typed `StrategyConfig` Value Objects, then config/strategy type consistency
+2. Decide whether GET query environment validation should move earlier or remain
    explicitly documented as service-level validation
+3. Continue working through the `Flag` DDD analysis backlog
 
-**Phase 1.5 closed with GO WITH CONDITIONS; AI output-contract condition is closed.
-Phase 2 first invariant landed in PR #59 (archived state is terminal).**
+**Phase 2 progress: archived state terminal (PR #59), `IsSeeded` removed from domain,
+archived-flag integration test coverage complete. Next: typed `StrategyConfig` Value Objects.**
 
 ---
 

--- a/docs/decisions/test-archived-flag-409-integration/implementation-notes.md
+++ b/docs/decisions/test-archived-flag-409-integration/implementation-notes.md
@@ -1,0 +1,109 @@
+# Archived-Flag Integration Test Coverage — Implementation Notes
+
+**Session date:** 2026-05-05
+**Branch:** test/archived-flag-409-integration
+**Spec reference:** docs/decisions/test-archived-flag-409-integration/spec.md
+**Build status:** Passing — 0 warnings, 0 errors
+**Tests:** 169/169 passing (115 unit + 54 integration)
+**PR:** TBD
+
+## What Was Built
+
+Four integration tests that close the deferred gap from PR #59. Three tests verify
+that the HTTP API returns 404 when clients attempt to mutate archived flags (PUT,
+DELETE, and evaluate), documenting that the repository's `!f.IsArchived` filter is the
+primary enforcement mechanism. One synthetic test verifies the `FlagDomainException` →
+409 ProblemDetails middleware contract via a test-only endpoint registered through
+`IStartupFilter` in `BanderasApiFactory`.
+
+## Spec Gaps Resolved
+
+None — implementation matched the spec exactly.
+
+## Deviations from Spec
+
+The spec's Technical Note 1 suggested `app.MapGet("/test/throw-domain-exception", ...)`
+inside `ConfigureWebHost`. The implementation used `IStartupFilter` with
+`IApplicationBuilder.Map()` instead, because `WebApplicationFactory` does not expose
+`WebApplication`'s minimal API `MapGet` from the `ConfigureWebHost` override. The
+`IStartupFilter` approach achieves the same result — a test-only endpoint that throws
+`FlagDomainException` downstream of `GlobalExceptionMiddleware` — without requiring
+access to the `WebApplication` instance.
+
+## Key Decisions
+
+1. **`IStartupFilter` with `next(app)` first** — calling `next(app)` before registering
+   the test middleware ensures it is added at the end of the pipeline, downstream of
+   `GlobalExceptionMiddleware`. This means the exception bubbles back up through the
+   real middleware, giving a genuine integration test of the 409 mapping.
+
+2. **`IApplicationBuilder.Map()` for path branching** — used `Map("/test/...", branch
+   => branch.Run(...))` to isolate the test endpoint to a specific path without
+   interfering with the rest of the pipeline. Unmatched paths pass through normally.
+
+3. **Asserting `detail` content, not exact message** — the 409 middleware test asserts
+   that `detail` contains `"test-flag"` and `"archived and cannot be modified"` rather
+   than an exact string match, making the test resilient to minor message rewording.
+
+## File-by-File Changes
+
+| File | Change |
+|------|--------|
+| `Banderas.Tests.Integration/Fixtures/BanderasApiFactory.cs` | Added `using` for `Banderas.Domain.Exceptions` and `Microsoft.AspNetCore.Builder`. Registered `TestDomainExceptionEndpointFilter` as `IStartupFilter`. Added private `TestDomainExceptionEndpointFilter` class that maps `GET /test/throw-domain-exception` and throws `FlagDomainException`. |
+| `Banderas.Tests.Integration/FlagEndpointTests.cs` | Added `UpdateFlag_ArchivedFlag_Returns404ProblemDetailsAsync` and `ArchiveFlag_AlreadyArchived_Returns404ProblemDetailsAsync`. Both follow the create-then-archive-then-mutate pattern. |
+| `Banderas.Tests.Integration/EvaluationEndpointTests.cs` | Added `Evaluate_ArchivedFlag_Returns404Async`. Creates a flag, archives it, then attempts evaluation. |
+| `Banderas.Tests.Integration/ArchivedFlag409MiddlewareTests.cs` | **New file.** Single test class with `FlagDomainException_Returns409ConflictProblemDetailsAsync` that hits the synthetic test endpoint and asserts 409 status, `application/problem+json` content type, `"Conflict"` title, and exception message in `detail`. |
+
+## Risks and Follow-Ups
+
+- **Test count drift** — current-state.md previously listed 117 unit tests but the
+  actual count is 115. This was pre-existing (not caused by this PR). The doc has been
+  updated to reflect the actual count.
+- **`IStartupFilter` ordering with minimal hosting** — the current approach works
+  because `next(app)` is called first, placing the test middleware at the end of the
+  pipeline. If the app's startup pipeline changes significantly (e.g., switching to a
+  different hosting model), the test endpoint ordering should be re-verified.
+
+## How to Test
+
+```bash
+# Run just the 4 new tests
+dotnet test Banderas.Tests.Integration \
+  --filter "UpdateFlag_ArchivedFlag|ArchiveFlag_AlreadyArchived|Evaluate_ArchivedFlag|FlagDomainException_Returns409" \
+  --verbosity normal
+
+# Run full suite
+dotnet test Banderas.sln --verbosity normal
+```
+
+## Interview Lens
+
+The most interesting decision was how to integration-test a middleware mapping that no
+real HTTP endpoint currently triggers. The repository layer filters archived flags
+before the domain guard fires, so `PUT`/`DELETE` on an archived flag returns 404, not
+409. But the `FlagDomainException` → 409 middleware path exists as a defense-in-depth
+contract. Rather than coupling the test to repository internals or bypassing the filter,
+we registered a synthetic test-only endpoint via `IStartupFilter` that throws the
+domain exception directly. This keeps the test honest — it exercises the real middleware
+pipeline without misrepresenting the API's actual behavior. At higher scale with more
+exception types, I'd consider a parameterized test fixture that registers multiple
+synthetic endpoints from a list of exception-to-status mappings, turning the middleware
+contract into a data-driven test suite.
+
+## Foundation Docs Updated
+
+- [x] `Docs/current-state.md` — status summary, test counts, test section, current
+  focus, lessons learned
+- [x] `Docs/roadmap.md` — Phase 2 checklist items, phase map status, current focus
+- [ ] `Docs/architecture.md` — no changes needed (no new production components)
+
+## Definition of Done — Status
+
+- [x] `PUT` on archived flag returns 404 — `UpdateFlag_ArchivedFlag_Returns404ProblemDetailsAsync`
+- [x] `DELETE` on already-archived flag returns 404 — `ArchiveFlag_AlreadyArchived_Returns404ProblemDetailsAsync`
+- [x] `POST /api/evaluate` on archived flag returns 404 — `Evaluate_ArchivedFlag_Returns404Async`
+- [x] Synthetic `FlagDomainException` → 409 ProblemDetails shape — `FlagDomainException_Returns409ConflictProblemDetailsAsync`
+- [x] All existing tests still pass (169/169)
+- [x] `dotnet build -p:TreatWarningsAsErrors=true` passes
+- [x] CSharpier format check passes
+- [x] No production code modified

--- a/docs/decisions/test-archived-flag-409-integration/spec.md
+++ b/docs/decisions/test-archived-flag-409-integration/spec.md
@@ -1,0 +1,226 @@
+# Specification: Archived-Flag Integration Test Coverage
+
+**Document:** docs/decisions/test-archived-flag-409-integration/spec.md
+**Status:** Draft
+**Branch:** test/archived-flag-409-integration
+**PR:** TBD
+**Phase:** Phase 2 — Testing & Reliability
+**Depends on:** None (PR #59 already merged)
+**Author:** Developer
+**Date:** 2026-05-05
+
+## Table of Contents
+
+- [User Story](#user-story)
+- [Background and Goals](#background-and-goals)
+- [Design Decisions](#design-decisions)
+- [Architecture Overview](#architecture-overview)
+- [Scope](#scope)
+- [Acceptance Criteria](#acceptance-criteria)
+- [File Layout](#file-layout)
+- [Technical Notes](#technical-notes)
+- [Out of Scope](#out-of-scope)
+- [Learning Opportunities](#learning-opportunities)
+- [Definition of Done](#definition-of-done)
+
+## User Story
+
+As a developer maintaining the Banderas API, I want integration tests that verify
+the HTTP behavior when clients attempt to mutate archived flags, so that the archival
+boundary is covered end-to-end and not just verified by code inspection.
+
+## Background and Goals
+
+PR #59 landed archived-as-terminal domain guards on all five `Flag` mutation methods
+and 10 unit tests in `FlagArchivedInvariantTests`. API-level integration coverage was
+explicitly deferred to a Phase 2 follow-up. The current-state doc calls this out as an
+immediate next task.
+
+**Goals:**
+
+1. **Close the deferred gap from PR #59** — prove the HTTP surface behaves correctly
+   when clients target archived flags.
+2. **Document the architectural reality** — the repository filter (`!f.IsArchived` on
+   all queries) is the primary guard, returning 404 before the domain exception can
+   fire. Tests should assert what actually happens (404), not what the domain guards
+   throw (409).
+3. **Cover the middleware 409 contract** — even though the HTTP API does not currently
+   trigger `FlagDomainException`, the middleware mapping exists and should have at
+   least one integration test proving the ProblemDetails shape is correct for when
+   future code paths reach it.
+
+## Design Decisions
+
+### DD-1: Test what the API actually returns, not what the domain guards throw
+
+The repository filters archived flags with `!f.IsArchived`, so `PUT` and `DELETE` on
+an archived flag return 404, not 409. Tests assert 404 — that is the real contract
+clients see. Testing 409 via HTTP would require bypassing the repo filter, which
+misrepresents the API's behavior.
+
+**Tradeoff:** The `FlagDomainException` -> 409 middleware path is not exercised via a
+real user flow. Acceptable because unit tests already cover the domain guards, and the
+middleware mapping is covered separately (DD-2).
+
+### DD-2: One dedicated middleware-level test for the 409 ProblemDetails shape
+
+Register a test-only endpoint in `BanderasApiFactory` that throws
+`FlagDomainException`, then assert the response is RFC 9457 ProblemDetails with
+status 409, title "Conflict", and the exception message in `detail`.
+
+**Tradeoff:** This is a synthetic test that does not exercise a real user flow. But it
+is the only way to cover the middleware contract without coupling to implementation
+details of the repository filter. The alternative (no 409 shape test) leaves the
+middleware mapping verified only by inspection.
+
+### DD-3: Include archived-flag evaluation in scope
+
+`POST /api/evaluate` against an archived flag should also return 404 (repository
+filter). This is a distinct user-visible behavior worth covering — a client might
+reasonably try to evaluate a flag that was recently archived.
+
+**Tradeoff:** Small scope increase (one test), but closes an obvious gap in
+`EvaluationEndpointTests`.
+
+## Architecture Overview
+
+No new production components. No layer boundaries crossed. Purely additive test code.
+
+**Test topology:**
+
+```
+BanderasApiFactory (existing)
+├── Registers test-only endpoint: GET /test/throw-domain-exception
+│   └── Throws FlagDomainException directly → middleware catches → 409 ProblemDetails
+│
+FlagEndpointTests (existing file, new tests)
+├── PUT archived flag → 404
+├── DELETE already-archived flag → 404
+│
+EvaluationEndpointTests (existing file, new tests)
+├── POST /api/evaluate archived flag → 404
+│
+ArchivedFlag409MiddlewareTests (new file)
+├── GET /test/throw-domain-exception → 409 ProblemDetails shape assertion
+```
+
+The test-only endpoint lives inside `BanderasApiFactory`'s `ConfigureWebHost`
+override — it never ships in production.
+
+## Scope
+
+### Files modified
+
+| File | Change |
+|------|--------|
+| `Banderas.Tests.Integration/Fixtures/BanderasApiFactory.cs` | Register test-only endpoint that throws `FlagDomainException` |
+| `Banderas.Tests.Integration/FlagEndpointTests.cs` | Add 2 tests: PUT archived → 404, DELETE already-archived → 404 |
+| `Banderas.Tests.Integration/EvaluationEndpointTests.cs` | Add 1 test: evaluate archived flag → 404 |
+
+### Files created
+
+| File | Purpose |
+|------|---------|
+| `Banderas.Tests.Integration/ArchivedFlag409MiddlewareTests.cs` | 1 test: synthetic `FlagDomainException` → 409 ProblemDetails shape |
+
+### Files not touched
+
+Zero changes to anything under `Banderas.Api/`, `Banderas.Application/`,
+`Banderas.Domain/`, or `Banderas.Infrastructure/`.
+
+## Acceptance Criteria
+
+### AC-1: PUT on archived flag returns 404
+
+- **Given** a flag exists and has been archived via
+  `DELETE /api/flags/{name}?environment=Development`
+- **When** a client sends `PUT /api/flags/{name}?environment=Development` with a
+  valid `UpdateFlagRequest`
+- **Then** the response is `404 Not Found` with `application/problem+json` content type
+
+### AC-2: DELETE on already-archived flag returns 404
+
+- **Given** a flag has already been archived
+- **When** a client sends `DELETE /api/flags/{name}?environment=Development`
+- **Then** the response is `404 Not Found` with `application/problem+json` content type
+
+### AC-3: Evaluate archived flag returns 404
+
+- **Given** a flag has been archived
+- **When** a client sends `POST /api/evaluate` with that flag's name and environment
+- **Then** the response is `404 Not Found` with `application/problem+json` content type
+
+### AC-4: FlagDomainException middleware mapping produces correct 409 ProblemDetails
+
+- **Given** a request hits an endpoint that throws `FlagDomainException`
+- **When** the middleware catches it
+- **Then** the response status is `409`
+- **And** content type is `application/problem+json`
+- **And** body contains `title: "Conflict"`, `status: 409`, and `detail` matching the
+  exception message
+
+## File Layout
+
+```
+Banderas.Tests.Integration/
+├── Fixtures/
+│   └── BanderasApiFactory.cs          (modified — test-only endpoint)
+├── FlagEndpointTests.cs               (modified — +2 tests)
+├── EvaluationEndpointTests.cs         (modified — +1 test)
+└── ArchivedFlag409MiddlewareTests.cs   (new — +1 test)
+```
+
+## Technical Notes
+
+1. **Test-only endpoint registration** — Use `app.MapGet("/test/throw-domain-exception", ...)`
+   inside `BanderasApiFactory.ConfigureWebHost`. The endpoint throws
+   `new FlagDomainException("Test flag 'x' is archived and cannot be modified.")`.
+   This never appears in the production route table.
+
+2. **Test setup pattern for archived flags** — Each test creates a flag via
+   `POST /api/flags`, archives it via `DELETE /api/flags/{name}?environment=Development`,
+   then attempts the mutation. This follows the existing create-then-archive pattern in
+   `ArchiveFlag_Exists_Returns204AndExcludedFromGetAllAsync`.
+
+3. **ProblemDetails deserialization** — Use `System.Text.Json` to deserialize the
+   response body as `JsonDocument` and assert individual properties (`status`, `title`,
+   `detail`, `type`). This avoids coupling to a specific ProblemDetails DTO. Existing
+   integration tests already use this approach.
+
+4. **No new NuGet packages required.**
+
+5. **Test count impact** — Net +4 integration tests (48 → 52). Test naming follows the
+   existing `Method_Scenario_ExpectedResultAsync` convention with
+   `[Trait("Category", "Integration")]`.
+
+## Out of Scope
+
+- No production code changes — no controller `[ProducesResponseType]` additions, no
+  repository changes, no domain changes
+- No unarchive endpoint — deferred to Phase 3 (requires auth + audit trail per DD-4
+  in PR #59)
+- No typed `StrategyConfig` Value Objects — separate Phase 2 item
+- No contract tests for non-archived API responses — separate Phase 2 backlog item
+- No mutation testing — separate Phase 2 backlog item
+
+## Learning Opportunities
+
+1. **WebApplicationFactory test-only endpoints** — registering synthetic routes inside
+   the test host to isolate middleware behavior without coupling to real service flows.
+   A pattern that transfers to any ASP.NET Core project.
+
+2. **Defense-in-depth testing strategy** — when two layers guard the same invariant
+   (repository filter + domain guard), integration tests should assert what clients
+   actually see (404), while targeted synthetic tests cover the secondary guard (409
+   middleware mapping).
+
+## Definition of Done
+
+- [ ] `PUT` on archived flag returns 404 — integration test passing
+- [ ] `DELETE` on already-archived flag returns 404 — integration test passing
+- [ ] `POST /api/evaluate` on archived flag returns 404 — integration test passing
+- [ ] Synthetic `FlagDomainException` → 409 ProblemDetails shape — integration test passing
+- [ ] All existing tests still pass (165 + 4 = 169)
+- [ ] `dotnet build -p:TreatWarningsAsErrors=true` passes
+- [ ] CSharpier format check passes
+- [ ] No production code modified


### PR DESCRIPTION
## Summary

  Four integration tests closing the deferred gap from PR #59. Three tests verify that the HTTP API returns 404 when clients attempt to mutate archived flags (PUT, DELETE, and evaluate), documenting that the
  repository's `!f.IsArchived` filter is the primary enforcement mechanism. One synthetic test verifies the `FlagDomainException` → 409 ProblemDetails middleware contract via a test-only endpoint registered
  through `IStartupFilter` in `BanderasApiFactory`.

  ## Changes in this PR

  - **Integration tests:** 3 archived-flag mutation tests (PUT → 404, DELETE → 404, evaluate → 404) in existing test files
  - **Middleware contract test:** New `ArchivedFlag409MiddlewareTests` with synthetic `FlagDomainException` → 409 assertion
  - **Test infrastructure:** `TestDomainExceptionEndpointFilter` (`IStartupFilter`) in `BanderasApiFactory` registers `GET /test/throw-domain-exception`
  - **Foundation docs:** Updated `current-state.md` and `roadmap.md` with Phase 2 progress, test counts, and lessons learned

  ## Spec

  `docs/decisions/test-archived-flag-409-integration/spec.md`

  ## Implementation Notes

  `docs/decisions/test-archived-flag-409-integration/implementation-notes.md`

  ## Definition of Done

  - [x] `PUT` on archived flag returns 404 — integration test passing
  - [x] `DELETE` on already-archived flag returns 404 — integration test passing
  - [x] `POST /api/evaluate` on archived flag returns 404 — integration test passing
  - [x] Synthetic `FlagDomainException` → 409 ProblemDetails shape — integration test passing
  - [x] All existing tests still pass (169/169)
  - [x] `dotnet build -p:TreatWarningsAsErrors=true` passes
  - [x] CSharpier format check passes
  - [x] No production code modified

  ## Testing

  ```bash
  # Run just the 4 new tests
  dotnet test Banderas.Tests.Integration \
    --filter "UpdateFlag_ArchivedFlag|ArchiveFlag_AlreadyArchived|Evaluate_ArchivedFlag|FlagDomainException_Returns409" \
    --verbosity normal

  # Run full suite
  dotnet test Banderas.sln --verbosity normal