### PR TITLE
refactor(domain): Consolidate Flag mutation methods by concern — Phase 2

### DIFF
--- a/Banderas.Application/Services/BanderasService.cs
+++ b/Banderas.Application/Services/BanderasService.cs
@@ -183,12 +183,12 @@ public sealed class BanderasService : IBanderasService
             await _repository.GetByNameAsync(name, environment, ct)
             ?? throw new FlagNotFoundException(name);
 
-        // Single atomic update — sets UpdatedAt exactly once
+        // Atomic rollout reconfiguration — sets UpdatedAt exactly once
         StrategyConfig strategyConfig = _configFactory.Create(
             request.StrategyType,
             request.StrategyConfig
         );
-        flag.Update(request.IsEnabled, request.StrategyType, strategyConfig);
+        flag.Reconfigure(request.IsEnabled, request.StrategyType, strategyConfig);
         await _repository.SaveChangesAsync(ct);
     }
 

--- a/Banderas.Domain/Entities/Flag.cs
+++ b/Banderas.Domain/Entities/Flag.cs
@@ -70,37 +70,6 @@ public class Flag
         StrategyConfig = new StrategyConfig(RolloutStrategy.None, "{}");
     }
 
-    public void SetEnabled(bool enabled)
-    {
-        if (IsArchived)
-        {
-            throw new FlagDomainException($"Flag '{Name}' is archived and cannot be modified.");
-        }
-
-        IsEnabled = enabled;
-        UpdatedAt = DateTime.UtcNow;
-    }
-
-    public void UpdateStrategy(RolloutStrategy strategyType, StrategyConfig strategyConfig)
-    {
-        if (IsArchived)
-        {
-            throw new FlagDomainException($"Flag '{Name}' is archived and cannot be modified.");
-        }
-
-        if (strategyConfig.ValidatedFor != strategyType)
-        {
-            throw new FlagDomainException(
-                $"StrategyConfig was validated for '{strategyConfig.ValidatedFor}' "
-                    + $"but Flag strategy is '{strategyType}'."
-            );
-        }
-
-        StrategyType = strategyType;
-        StrategyConfig = strategyConfig;
-        UpdatedAt = DateTime.UtcNow;
-    }
-
     public void UpdateName(string name)
     {
         if (IsArchived)
@@ -118,10 +87,14 @@ public class Flag
     }
 
     /// <summary>
-    /// Atomically updates the enabled state and rollout strategy in a single
-    /// operation, setting UpdatedAt exactly once.
+    /// Atomically replaces the rollout configuration (enabled state, strategy type,
+    /// and strategy config) in a single operation, setting UpdatedAt exactly once.
     /// </summary>
-    public void Update(bool isEnabled, RolloutStrategy strategyType, StrategyConfig strategyConfig)
+    public void Reconfigure(
+        bool isEnabled,
+        RolloutStrategy strategyType,
+        StrategyConfig strategyConfig
+    )
     {
         if (IsArchived)
         {

--- a/Banderas.Tests.Integration/FlagConcurrencyTokenTests.cs
+++ b/Banderas.Tests.Integration/FlagConcurrencyTokenTests.cs
@@ -58,7 +58,7 @@ public sealed class FlagConcurrencyTokenTests : IntegrationTestBase
         Flag flagA = (await dbA.Flags.FindAsync(flagId))!;
         Flag flagB = (await dbB.Flags.FindAsync(flagId))!;
 
-        flagA.SetEnabled(true);
+        flagA.Reconfigure(isEnabled: true, RolloutStrategy.None, flagA.StrategyConfig);
         await dbA.SaveChangesAsync();
 
         flagB.UpdateName("renamed-by-loser");

--- a/Banderas.Tests/Domain/FlagArchivedInvariantTests.cs
+++ b/Banderas.Tests/Domain/FlagArchivedInvariantTests.cs
@@ -12,31 +12,6 @@ public sealed class FlagArchivedInvariantTests
 {
     [Fact]
     [Trait("Category", "Unit")]
-    public void SetEnabled_WhenFlagIsArchived_ThrowsFlagDomainException()
-    {
-        Flag flag = FlagBuilder.Build();
-        flag.Archive();
-
-        Action act = () => flag.SetEnabled(true);
-
-        act.Should().Throw<FlagDomainException>();
-    }
-
-    [Fact]
-    [Trait("Category", "Unit")]
-    public void UpdateStrategy_WhenFlagIsArchived_ThrowsFlagDomainException()
-    {
-        Flag flag = FlagBuilder.Build();
-        flag.Archive();
-
-        var config = new StrategyConfig(RolloutStrategy.None, "{}");
-        Action act = () => flag.UpdateStrategy(RolloutStrategy.None, config);
-
-        act.Should().Throw<FlagDomainException>();
-    }
-
-    [Fact]
-    [Trait("Category", "Unit")]
     public void UpdateName_WhenFlagIsArchived_ThrowsFlagDomainException()
     {
         Flag flag = FlagBuilder.Build();
@@ -49,13 +24,13 @@ public sealed class FlagArchivedInvariantTests
 
     [Fact]
     [Trait("Category", "Unit")]
-    public void Update_WhenFlagIsArchived_ThrowsFlagDomainException()
+    public void Reconfigure_WhenFlagIsArchived_ThrowsFlagDomainException()
     {
         Flag flag = FlagBuilder.Build();
         flag.Archive();
 
         var config = new StrategyConfig(RolloutStrategy.None, "{}");
-        Action act = () => flag.Update(false, RolloutStrategy.None, config);
+        Action act = () => flag.Reconfigure(false, RolloutStrategy.None, config);
 
         act.Should().Throw<FlagDomainException>();
     }
@@ -74,30 +49,6 @@ public sealed class FlagArchivedInvariantTests
 
     [Fact]
     [Trait("Category", "Unit")]
-    public void SetEnabled_WhenFlagIsNotArchived_Succeeds()
-    {
-        Flag flag = FlagBuilder.Build(isEnabled: false);
-
-        flag.SetEnabled(true);
-
-        flag.IsEnabled.Should().BeTrue();
-    }
-
-    [Fact]
-    [Trait("Category", "Unit")]
-    public void UpdateStrategy_WhenFlagIsNotArchived_Succeeds()
-    {
-        Flag flag = FlagBuilder.Build();
-        var config = new StrategyConfig(RolloutStrategy.Percentage, """{"percentage":50}""");
-
-        flag.UpdateStrategy(RolloutStrategy.Percentage, config);
-
-        flag.StrategyType.Should().Be(RolloutStrategy.Percentage);
-        flag.StrategyConfig.RawJson.Should().Be("""{"percentage":50}""");
-    }
-
-    [Fact]
-    [Trait("Category", "Unit")]
     public void UpdateName_WhenFlagIsNotArchived_Succeeds()
     {
         Flag flag = FlagBuilder.Build();
@@ -109,12 +60,12 @@ public sealed class FlagArchivedInvariantTests
 
     [Fact]
     [Trait("Category", "Unit")]
-    public void Update_WhenFlagIsNotArchived_Succeeds()
+    public void Reconfigure_WhenFlagIsNotArchived_Succeeds()
     {
         Flag flag = FlagBuilder.Build(isEnabled: true);
         var config = new StrategyConfig(RolloutStrategy.Percentage, """{"percentage":25}""");
 
-        flag.Update(false, RolloutStrategy.Percentage, config);
+        flag.Reconfigure(false, RolloutStrategy.Percentage, config);
 
         flag.IsEnabled.Should().BeFalse();
         flag.StrategyType.Should().Be(RolloutStrategy.Percentage);

--- a/Banderas.Tests/Domain/ValueObjects/StrategyConfigTests.cs
+++ b/Banderas.Tests/Domain/ValueObjects/StrategyConfigTests.cs
@@ -86,29 +86,14 @@ public sealed class StrategyConfigTests
 
     [Fact]
     [Trait("Category", "Unit")]
-    public void FlagUpdate_WithMismatchedConfig_ThrowsFlagDomainException()
+    public void FlagReconfigure_WithMismatchedConfig_ThrowsFlagDomainException()
     {
         // Arrange
         Flag flag = FlagBuilder.Build();
         var config = new StrategyConfig(RolloutStrategy.Percentage, """{"percentage":50}""");
 
         // Act
-        Action act = () => flag.Update(true, RolloutStrategy.RoleBased, config);
-
-        // Assert
-        act.Should().Throw<FlagDomainException>();
-    }
-
-    [Fact]
-    [Trait("Category", "Unit")]
-    public void FlagUpdateStrategy_WithMismatchedConfig_ThrowsFlagDomainException()
-    {
-        // Arrange
-        Flag flag = FlagBuilder.Build();
-        var config = new StrategyConfig(RolloutStrategy.Percentage, """{"percentage":50}""");
-
-        // Act
-        Action act = () => flag.UpdateStrategy(RolloutStrategy.RoleBased, config);
+        Action act = () => flag.Reconfigure(true, RolloutStrategy.RoleBased, config);
 
         // Assert
         act.Should().Throw<FlagDomainException>();

--- a/Docs/Decisions/flag-ddd-analysis-backlog.md
+++ b/Docs/Decisions/flag-ddd-analysis-backlog.md
@@ -77,7 +77,7 @@ public class FlagEnvironmentConfig
 - [X] **Introduce `FlagDomainException`** — dedicated domain exception type; thrown by domain invariant violations; lives in `Banderas.Domain`
 - [X] **Enforce archived state as terminal** — guard clause at top of `Archive()`, `SetEnabled()`, `UpdateStrategy()`, `Update()`, and `UpdateName()`; throw `FlagDomainException` if already archived (PR #59)
 - [X] **Remove `IsSeeded` from `Flag`** — move to infrastructure seeding concern; its presence on the domain entity is a boundary violation _(shipped as EF Core shadow property; second `Flag` constructor deleted; PR TBD)_
-- [ ] **Consolidate `SetEnabled()` + `UpdateStrategy()` + `Update()`** — separate by concern not field; name changes (`UpdateName()`) are a distinct operation; rollout config changes are one operation
+- [X] **Consolidate `SetEnabled()` + `UpdateStrategy()` + `Update()`** — separate by concern not field; name changes (`UpdateName()`) are a distinct operation; rollout config changes are one operation _(shipped: `SetEnabled` and `UpdateStrategy` deleted, `Update` renamed to `Reconfigure`; PR TBD)_
 - [ ] **Convert `StrategyConfig` from raw `string` to typed Value Objects** — one Value Object per strategy type (e.g. `PercentageConfig`, `RoleBasedConfig`); invalid config caught at construction
 - [ ] **Enforce config/strategy type consistency inside `Flag`** — `Flag` rejects a `PercentageConfig` when `StrategyType` is `RoleBased`; illegal state becomes unrepresentable
 - [ ] **Add `Description` to `Flag` definition** — environment-agnostic metadata

--- a/Docs/Decisions/refactor-flag-mutation-consolidation/implementation-notes.md
+++ b/Docs/Decisions/refactor-flag-mutation-consolidation/implementation-notes.md
@@ -1,0 +1,171 @@
+# Consolidate `Flag` Mutation Methods by Concern — Implementation Notes
+
+**Session date:** 2026-05-11
+**Branch:** refactor/flag-mutation-consolidation
+**Spec reference:** Docs/Decisions/refactor-flag-mutation-consolidation/spec.md
+**Build status:** ✅ `dotnet build -p:TreatWarningsAsErrors=true` — 0 warnings, 0 errors
+**Tests:** 153/153 unit + 54/54 integration passing (207/207 total)
+**PR:** TBD
+
+---
+
+## What Was Built
+
+The `Flag` aggregate now exposes a single concern-named rollout mutation,
+`Reconfigure(bool, RolloutStrategy, StrategyConfig)`, in place of the previous
+trio `SetEnabled` / `UpdateStrategy` / `Update`. The two field-shaped methods
+(`SetEnabled`, `UpdateStrategy`) had no production callers and were deleted; the
+atomic `Update` method was renamed to `Reconfigure` to declare full atomic
+replacement, not partial patching. `UpdateName` and `Archive` are unchanged.
+The public HTTP API, DTO contracts, and `IBanderasService` signatures are all
+identical to before — this is a pure domain-layer rename + delete with a
+single application-layer call-site update.
+
+## Spec Gaps Resolved
+
+None. The spec was specific enough to execute without stopping for clarification.
+
+## Deviations from Spec
+
+- **Test count delta is 5, not 3 as the spec predicted.** The spec foresaw three
+  folded tests (two archived-guards + one mismatch). The actual drops also include
+  the two "non-archived succeeds" companions for `SetEnabled` and `UpdateStrategy`,
+  which no longer have a method to exercise. The surviving
+  `Reconfigure_WhenFlagIsNotArchived_Succeeds` test asserts all three fields
+  (`IsEnabled`, `StrategyType`, `StrategyConfig`), so observable coverage of the
+  success path is preserved. No coverage gap — the prediction was simply off by
+  two trivial tests.
+
+## Key Decisions
+
+- **`Reconfigure` over `Configure`.** `Configure` reads as first-time setup and
+  blurs with the .NET DI/extension idiom (`services.Configure<T>`, `IConfigureOptions`).
+  The `re-` prefix signals that initial configuration happens in the constructor
+  and every subsequent call is a replacement, not a setup.
+- **XML doc rewritten, not just transplanted.** The former `Update` doc began
+  "Atomically updates the enabled state and rollout strategy" — a description of
+  fields. The new `Reconfigure` doc reads "Atomically replaces the rollout
+  configuration (enabled state, strategy type, and strategy config) in a single
+  operation" — a description of the concern. Small change, large signal.
+- **Concurrency test mutation kept neutral.** `FlagConcurrencyTokenTests` calls
+  `flagA.Reconfigure(true, RolloutStrategy.None, flagA.StrategyConfig)` —
+  reusing the loaded `StrategyConfig` rather than constructing a new one. The
+  test exists to demonstrate the optimistic concurrency token; the specific
+  mutation is incidental and the no-op-on-strategy form keeps the test focused
+  on the version-collision behavior rather than a strategy change.
+- **Backlog item closed in place.** `Docs/Decisions/flag-ddd-analysis-backlog.md`
+  line 80 is now `[X]` with a one-line provenance note pointing back to this PR,
+  matching the prior `IsSeeded` removal's convention.
+
+## File-by-File Changes
+
+| File | Change |
+|---|---|
+| `Banderas.Domain/Entities/Flag.cs` | Deleted `SetEnabled(bool)` and `UpdateStrategy(RolloutStrategy, StrategyConfig)`. Renamed `Update(...)` → `Reconfigure(...)`. Rewrote the XML doc to describe the concern instead of the fields. Reflowed the signature across three lines to satisfy CSharpier on the longer method name. No behavior change on the surviving method body. |
+| `Banderas.Application/Services/BanderasService.cs` | `UpdateFlagAsync` now calls `flag.Reconfigure(...)`. The adjacent comment changed from "Single atomic update" to "Atomic rollout reconfiguration" — same intent, named for the concern. |
+| `Banderas.Tests/Domain/FlagArchivedInvariantTests.cs` | Dropped the four tests that exercised the deleted methods (`SetEnabled` and `UpdateStrategy`, both archived-guard and success). Renamed the `Update`-shaped tests to `Reconfigure`. File shrinks from 10 tests to 5 (Reconfigure × 2, UpdateName × 2, Archive × 2 — minus one because `Reconfigure_WhenFlagIsArchived_ThrowsFlagDomainException` is one test, not two). |
+| `Banderas.Tests/Domain/ValueObjects/StrategyConfigTests.cs` | Renamed `FlagUpdate_WithMismatchedConfig_...` to `FlagReconfigure_WithMismatchedConfig_...`. Deleted the redundant `FlagUpdateStrategy_WithMismatchedConfig_...` test — same rule, no longer a separate surface to exercise. |
+| `Banderas.Tests.Integration/FlagConcurrencyTokenTests.cs` | Replaced `flagA.SetEnabled(true)` with `flagA.Reconfigure(true, RolloutStrategy.None, flagA.StrategyConfig)`. Test continues to demonstrate the optimistic concurrency contract: `flagA` saves first, `flagB.UpdateName("renamed-by-loser")` then races and the repository surfaces `FlagConcurrencyException` → 409 on the loser. |
+| `Docs/architecture.md` | Updated the Domain Integrity principle to name `Reconfigure` / `UpdateName` / `Archive` as the canonical mutation surface, and to state the surface is named by concern, not by field. (Also includes the prior env-validation ratification edit from earlier in the session — bundled on this branch because it was uncommitted in the main tree.) |
+| `Docs/current-state.md` | Added "Phase 2 — Consolidate Flag Mutation Methods by Concern: ✅ Complete" to the Status Summary. Updated the Flag-completed bullet to name `Reconfigure(...)`. Updated the archived-terminal description (3 methods, not 5). Updated the test count summary (153 unit, was 158). Added the 2026-05-11 Lessons Learned entry. Bumped the Immediate Next Tasks list to the next DDD backlog item (`Description` / `Tags`). |
+| `Docs/roadmap.md` | Checked off the consolidation item under the Phase 2 `Flag` invariants list. Extended the Phase 2 progress sentence. |
+| `Docs/Decisions/flag-ddd-analysis-backlog.md` | Checked off the consolidation backlog item with a one-line provenance note. |
+| `Docs/Decisions/refactor-flag-mutation-consolidation/spec.md` | Carried into the worktree from the main tree (where it was written during `/spec`). |
+| `Docs/Decisions/refactor-flag-mutation-consolidation/implementation-notes.md` | This file. |
+
+## Risks and Follow-Ups
+
+- **No EF Core / migration risk.** `Reconfigure` writes the same three private-setter
+  properties that `Update` wrote. The schema is unchanged. The `StrategyConfig`
+  backing-field + reconciling-getter pattern is untouched.
+- **No public API risk.** Every external surface (HTTP endpoints, DTOs,
+  `IBanderasService` signatures, OpenAPI document) is byte-for-byte identical.
+  The PUT integration suite passing without test changes is the strongest possible
+  proof of semantic equivalence.
+- **Future readers — be cautious about reintroducing `SetEnabled`.** If a future
+  feature genuinely requires partial mutation (e.g. a "quick toggle" endpoint that
+  flips enabled without touching strategy), the right move is to add a new
+  concern-named method (`ToggleEnabled`?) with explicit semantics — not to
+  resurrect `SetEnabled`. The 2026-05-11 Lessons Learned entry codifies this.
+- **DDD backlog also closes the typed-config item.** Reading the backlog file, the
+  typed `StrategyConfig` Value Object entry (line 81) was still unchecked despite
+  PR #62 having shipped. Not touched in this PR — separate hygiene concern.
+
+## How to Test
+
+**Domain unit tests** (cover AC-1 through AC-5):
+
+```bash
+dotnet test Banderas.Tests/Banderas.Tests.csproj --filter "FullyQualifiedName~FlagArchivedInvariantTests|FullyQualifiedName~StrategyConfigTests"
+```
+
+Expected: all archived-guard, success, and config-mismatch tests pass; no test
+references `SetEnabled` or `UpdateStrategy`.
+
+**Integration suite** (covers AC-6 byte-for-byte API parity and AC-7 concurrency):
+
+```bash
+dotnet test Banderas.Tests.Integration/Banderas.Tests.Integration.csproj
+```
+
+Expected: 54/54 green. `FlagConcurrencyTokenTests.ConcurrentUpdate_SecondSave_ThrowsFlagConcurrencyExceptionAsync`
+demonstrates the optimistic concurrency contract via `Reconfigure` + `UpdateName`.
+
+**Manual smoke** (no expected change vs. baseline):
+
+```bash
+# In another terminal: docker compose up
+# Then exercise the existing PUT path:
+curl -X PUT http://localhost:5051/api/flags/checkout-flow \
+  -H "Content-Type: application/json" \
+  -d '{"environment":"Development","isEnabled":true,"strategyType":"None","strategyConfig":null}'
+```
+
+Expected: `200 OK` with `FlagResponse` body, identical to the pre-refactor baseline.
+
+**Static check that no caller revived a deleted method:**
+
+```bash
+grep -rn "\.SetEnabled(\|\.UpdateStrategy(\|flag\.Update(" --include="*.cs" .
+```
+
+Expected: zero hits.
+
+## Interview Lens
+
+The interesting decision here was *what to keep and what to delete*, not *what to add*.
+`Flag` had three public methods that all touched the same domain concern, but only
+one had a production caller. Reading code from a DDD lens, the temptation is to
+preserve all three "in case someone needs them" — which is exactly the YAGNI trap.
+The cost of dead public surface is hidden but real: it invites future callers to
+patch one field and forget the others (toggle enabled while leaving a now-mismatched
+strategy untouched), and it tells future readers that the entity thinks in fields,
+not concerns. Deleting the dead methods and renaming the survivor to `Reconfigure`
+made the same domain rule unrepresentable in code rather than just documented. At
+a larger scale (a public NuGet SDK, say), I'd deprecate first with `[Obsolete]` for
+one release cycle before deletion; on an internal pre-1.0 codebase with one
+in-tree caller, that ceremony is overhead without benefit.
+
+## Foundation Docs Updated
+
+- [x] `Docs/architecture.md` — Domain Integrity principle reflects the new mutation surface
+- [x] `Docs/current-state.md` — Status Summary, Completed list, test counts, Next Tasks, Lessons Learned
+- [x] `Docs/roadmap.md` — Phase 2 backlog checkbox + progress sentence
+- [x] `Docs/Decisions/flag-ddd-analysis-backlog.md` — backlog item checked off
+- [x] `Docs/Decisions/refactor-flag-mutation-consolidation/implementation-notes.md` — this file
+
+## Definition of Done — Status
+
+- [x] ✅ `SetEnabled` and `UpdateStrategy` removed from `Flag.cs`
+- [x] ✅ `Update` renamed to `Reconfigure`; XML doc rewritten to name the concern
+- [x] ✅ `BanderasService.UpdateFlagAsync` calls `flag.Reconfigure(...)`
+- [x] ✅ No file in repo (excluding this spec) references `flag.SetEnabled(`, `flag.UpdateStrategy(`, or `flag.Update(` — verified by grep
+- [x] ✅ `FlagArchivedInvariantTests` covers `Reconfigure`, `UpdateName`, `Archive`; deleted method tests removed
+- [x] ✅ `StrategyConfigTests` references `Reconfigure` only; redundant `UpdateStrategy` mismatch test removed
+- [x] ✅ `FlagConcurrencyTokenTests` continues to demonstrate the optimistic concurrency contract
+- [x] ✅ `dotnet build -p:TreatWarningsAsErrors=true` succeeds across all projects (0/0)
+- [x] ✅ `dotnet csharpier check .` reports no violations (104 files)
+- [x] ✅ All unit tests pass (153/153 — 5 fewer than baseline, all due to deleted-method coverage being folded)
+- [x] ✅ All integration tests pass (54/54, count unchanged)
+- [x] ✅ `Requests/smoke-test.http` unchanged; PUT `/api/flags/{name}` returns the same `200 OK` `FlagResponse`
+- [x] ✅ PR description (to be written by `/git-workflow`) will reference the DDD backlog item being closed

--- a/Docs/Decisions/refactor-flag-mutation-consolidation/spec.md
+++ b/Docs/Decisions/refactor-flag-mutation-consolidation/spec.md
@@ -1,0 +1,258 @@
+# Specification: Consolidate `Flag` Mutation Methods by Concern
+
+**Document:** Docs/Decisions/refactor-flag-mutation-consolidation/spec.md
+**Status:** Draft
+**Branch:** refactor/flag-mutation-consolidation
+**PR:** TBD
+**Phase:** Phase 2 — Testing & Reliability (Flag DDD analysis backlog item)
+**Depends on:** None (typed `StrategyConfig` VO refactor, PR #62, already merged)
+**Author:** Developer
+**Date:** 2026-05-11
+
+---
+
+## Table of Contents
+
+- [User Story](#user-story)
+- [Background and Goals](#background-and-goals)
+- [Design Decisions](#design-decisions)
+- [Architecture Overview](#architecture-overview)
+- [Scope](#scope)
+- [Acceptance Criteria](#acceptance-criteria)
+- [File Layout](#file-layout)
+- [Technical Notes](#technical-notes)
+- [Out of Scope](#out-of-scope)
+- [Learning Opportunities](#learning-opportunities)
+- [DX / Tooling Idea](#dx--tooling-idea)
+- [Definition of Done](#definition-of-done)
+
+---
+
+## User Story
+
+**As** a future contributor extending `Flag` (adding variations, targeting rules, or a separate `FlagEnvironmentConfig` aggregate),
+**I want** the entity's mutation surface to be organized by domain concern rather than by individual field,
+**so that** I can reason about *what kind of change is happening* rather than mechanically wiring per-field setters, and so that the partial-mutation bug class (e.g. "did the caller intend to keep strategy unchanged?") is eliminated by construction.
+
+---
+
+## Background and Goals
+
+`Flag` today exposes four mutation methods:
+
+| Method | Mutates | Production caller |
+|---|---|---|
+| `SetEnabled(bool)` | `IsEnabled`, `UpdatedAt` | none (test-only) |
+| `UpdateStrategy(RolloutStrategy, StrategyConfig)` | `StrategyType`, `StrategyConfig`, `UpdatedAt` | none (test-only) |
+| `Update(bool, RolloutStrategy, StrategyConfig)` | `IsEnabled`, `StrategyType`, `StrategyConfig`, `UpdatedAt` | `BanderasService.UpdateFlagAsync` |
+| `UpdateName(string)` | `Name`, `UpdatedAt` | none (test-only) |
+
+`SetEnabled` and `UpdateStrategy` are field-shaped methods left over from an earlier draft of the domain model; the application layer never calls them. `Update` is the atomic rollout-config mutation that production actually uses. `UpdateName` is a distinct rename concern.
+
+The DDD analysis (`Docs/Decisions/flag-ddd-analysis-backlog.md`) identified that **`SetEnabled` + `UpdateStrategy` + `Update` are three slices of the same domain concern**: *changing how this flag rolls out for this environment.* The concern-level operation is "reconfigure the rollout"; the per-field methods are an artifact of CRUD thinking that bled into the domain.
+
+**Goals:**
+
+1. Reduce three mutation entry points to one whose name describes the *concern*, not the *fields*.
+2. Eliminate the public surface area for partial rollout updates (no caller can flip `IsEnabled` without restating strategy + config — removing a class of "stale strategy" bugs in any future caller).
+3. Preserve `UpdateName` as a separate concern (rename ≠ reconfigure).
+4. Zero changes to the public HTTP API, DTO contracts, or `IBanderasService` signatures.
+5. Preserve archived-state-terminal and config/strategy-consistency invariants exactly as they exist today.
+
+---
+
+## Design Decisions
+
+### DD-1 — Rename `Update` to `Reconfigure`; delete `SetEnabled` and `UpdateStrategy`
+
+**Decision:** The single rollout-mutation method on `Flag` is named `Reconfigure(bool isEnabled, RolloutStrategy strategyType, StrategyConfig strategyConfig)`. `SetEnabled` and `UpdateStrategy` are deleted.
+
+**Why a rename rather than keeping `Update`:** The backlog item is explicit — "separate by concern not field." `Update` is concern-blind; it reads as a generic CRUD verb. `Reconfigure` names the domain operation: *change this flag's rollout configuration as a single atomic act.* Naming is the load-bearing signal that the consolidation happened; without the rename, a future reader sees four mutation methods (now three) and assumes the same field-shaped thinking still applies.
+
+**Tradeoff:** One application call site (`BanderasService.UpdateFlagAsync` line 191) and four test files must be updated. Diff cost is small; clarity gain is durable.
+
+**Rejected alternative — `UpdateRollout`:** Less clear that the operation is *atomic and complete*, not a partial patch. `Reconfigure` carries the "starting over from the supplied values" connotation that matches the semantics (full replacement of the rollout triple).
+
+**Rejected alternative — keep `Update` and just delete the two field-shaped methods:** Half the refactor. The remaining method's name would still suggest the deleted methods are valid patterns ("if `Update` exists, why not `SetEnabled`?"). The rename closes the loop.
+
+### DD-2 — `UpdateName` stays a distinct concern, not folded into `Reconfigure`
+
+**Decision:** `UpdateName(string name)` remains a separate public method.
+
+**Why:** Rename is a metadata/display concern with different operational cadence (rare, often human-triggered for clarity), different validation rules (regex + uniqueness at the boundary), and different audit semantics (rename history is a separate question from rollout history). Coupling it to `Reconfigure` would force callers to restate the rollout config to change a name, or force `Reconfigure` to accept an optional name — either choice corrupts the concern boundary.
+
+**Tradeoff:** No atomic "rename + reconfigure" entry point. There is no production caller for that combined operation today; YAGNI applies.
+
+### DD-3 — No public API surface changes
+
+**Decision:** `IBanderasService`, request/response DTOs, controller signatures, and HTTP status codes are untouched. This is a pure domain-layer rename + delete with one downstream application-layer call-site update.
+
+**Why:** The change is a refactor of the domain's internal vocabulary, not a behavior change. Keeping the public API stable means no integration test needs to change to *prove the same behavior*, and the PR diff stays focused on the domain-model intent.
+
+**Tradeoff:** Integration tests that happen to call `Flag` directly (currently `FlagConcurrencyTokenTests`) still need a one-line edit. That's not a public API change — it's a test that reaches into the domain entity as a setup fixture.
+
+### DD-4 — Fold deleted-method tests into the surviving method's tests
+
+**Decision:** `FlagArchivedInvariantTests` currently has four archived-guard tests (one per mutation method). After this refactor it has two: one for `Reconfigure`, one for `UpdateName`. The deleted method tests are removed, not migrated.
+
+**Why:** The archived-state invariant is the same domain rule applied to every mutation. Testing it once per surviving method gives full coverage of the production surface; testing it on a deleted method tests nothing. The `StrategyConfig` mismatch test on `UpdateStrategy` similarly folds into the `Reconfigure` mismatch test — same rule, same surface.
+
+**Tradeoff:** Test count drops slightly. The lessons-learned note from 2026-05-05 ("test what clients see, not what guards throw") supports this — we are not reducing observable coverage, just the count of identical guards exercised at a private surface.
+
+---
+
+## Architecture Overview
+
+No new components. No layer boundary changes. No diagram required.
+
+The mutation surface of the `Flag` aggregate root is reduced from four methods to two:
+
+```
+Before                                After
+──────                                ─────
+Flag                                  Flag
+├── SetEnabled(bool)                  ├── Reconfigure(bool, RolloutStrategy, StrategyConfig)
+├── UpdateStrategy(RS, SC)            ├── UpdateName(string)
+├── Update(bool, RS, SC)              └── Archive()
+├── UpdateName(string)
+└── Archive()
+```
+
+All existing invariants are preserved on the surviving methods:
+- Archived-state-terminal guard fires first.
+- `Reconfigure` enforces `strategyConfig.ValidatedFor == strategyType` — same `FlagDomainException` as today.
+- `UpdatedAt` is set exactly once per mutation.
+- `Archive()` is unchanged.
+
+---
+
+## Scope
+
+Files modified:
+
+1. `Banderas.Domain/Entities/Flag.cs` — delete `SetEnabled`, delete `UpdateStrategy`, rename `Update` to `Reconfigure`. No signature change on the surviving method beyond the name.
+2. `Banderas.Application/Services/BanderasService.cs` — single call site at line 191 changes from `flag.Update(...)` to `flag.Reconfigure(...)`.
+3. `Banderas.Tests/Domain/FlagArchivedInvariantTests.cs` — remove the `SetEnabled` and `UpdateStrategy` archived-guard tests; rename the `Update` test to `Reconfigure`; remove the corresponding "non-archived succeeds" companions for the deleted methods. Keep `UpdateName` and `Archive` tests intact.
+4. `Banderas.Tests/Domain/ValueObjects/StrategyConfigTests.cs` — rename `flag.Update(...)` call to `flag.Reconfigure(...)`; remove the `UpdateStrategy` mismatch test (now redundant with the `Reconfigure` mismatch test).
+5. `Banderas.Tests.Integration/FlagConcurrencyTokenTests.cs` — replace `flagA.SetEnabled(true)` with `flagA.Reconfigure(true, /* preserve current strategy/config */)`. The test demonstrates the optimistic concurrency token; the specific mutation chosen is incidental.
+
+Files **not** modified:
+
+- `Banderas.Application/Interfaces/IBanderasService.cs` and DTOs — public service contract unchanged.
+- `Banderas.Api/Controllers/BanderasController.cs` — unchanged.
+- `Banderas.Infrastructure/Repositories/BanderasRepository.cs` and `FlagConfiguration.cs` — unchanged. EF Core sees the same private setters and the same property surface.
+- `Banderas.Tests.Integration/*` other than `FlagConcurrencyTokenTests` — no changes; PUT/POST/DELETE end-to-end tests continue to exercise the surviving `Reconfigure` path through the service.
+- `Requests/smoke-test.http` — HTTP surface unchanged.
+- Foundation docs (`architecture.md`, `current-state.md`, `roadmap.md`) — updated separately by `/post-work` after implementation review, not by this spec.
+
+---
+
+## Acceptance Criteria
+
+**AC-1 — `Reconfigure` updates the rollout triple atomically.**
+*Given* a non-archived `Flag` with `IsEnabled = false`, `StrategyType = None`, and a default `StrategyConfig`,
+*when* `flag.Reconfigure(true, RolloutStrategy.Percentage, percentageConfig)` is called,
+*then* `IsEnabled == true`, `StrategyType == Percentage`, `StrategyConfig == percentageConfig`, and `UpdatedAt` advances. All four fields move in one observable step.
+
+**AC-2 — `Reconfigure` honors the archived-terminal invariant.**
+*Given* an archived `Flag`,
+*when* `flag.Reconfigure(true, RolloutStrategy.None, anyConfig)` is called,
+*then* `FlagDomainException` is thrown with the message `"Flag '{Name}' is archived and cannot be modified."` and no fields change.
+
+**AC-3 — `Reconfigure` honors the config/strategy consistency invariant.**
+*Given* a non-archived `Flag` and a `StrategyConfig` whose `ValidatedFor != strategyType`,
+*when* `flag.Reconfigure(...)` is called with that mismatched pair,
+*then* `FlagDomainException` is thrown with a message identifying the mismatch and no fields change.
+
+**AC-4 — `UpdateName` is unaffected.**
+*Given* a non-archived `Flag`,
+*when* `flag.UpdateName("renamed")` is called,
+*then* `Name == "renamed"` and `UpdatedAt` advances. *Given* an archived `Flag`, calling `UpdateName` throws `FlagDomainException`. *Given* a whitespace name, `UpdateName` throws `ArgumentException`.
+
+**AC-5 — `SetEnabled` and `UpdateStrategy` are not callable.**
+*When* the solution is compiled,
+*then* no source file references `Flag.SetEnabled(` or `Flag.UpdateStrategy(`. Compilation fails if either is reintroduced as a public method.
+
+**AC-6 — `PUT /api/flags/{name}` behavior is byte-for-byte unchanged.**
+*Given* a valid `UpdateFlagRequest`,
+*when* the integration test suite runs against the API,
+*then* response status codes (200/400/404/409), `ProblemDetails` shapes, and persisted flag state match the existing test expectations exactly. No new integration assertions are required — existing PUT integration tests continue to pass without modification.
+
+**AC-7 — Optimistic concurrency contract is preserved.**
+*Given* two in-memory `Flag` instances loaded from the same row (`Version = N`),
+*when* one calls `Reconfigure(...)` and saves successfully, and the other then calls `UpdateName(...)` and attempts to save,
+*then* a `DbUpdateConcurrencyException` is raised on the loser. `FlagConcurrencyTokenTests` continues to demonstrate this exact contract.
+
+**AC-8 — Test suite is green.**
+*When* `dotnet test` runs both unit and integration projects,
+*then* all tests pass. The unit test count may decrease by 3 (folded archived-guard tests + folded `UpdateStrategy` mismatch test); the integration test count is unchanged at 54.
+
+---
+
+## File Layout
+
+```
+Banderas.Domain/Entities/Flag.cs                          MOD  (delete 2 methods, rename 1)
+Banderas.Application/Services/BanderasService.cs          MOD  (1 line, rename call)
+Banderas.Tests/Domain/FlagArchivedInvariantTests.cs       MOD  (delete 4 tests, rename 2)
+Banderas.Tests/Domain/ValueObjects/StrategyConfigTests.cs MOD  (delete 1 test, rename 1 call)
+Banderas.Tests.Integration/FlagConcurrencyTokenTests.cs   MOD  (replace 1 call)
+Docs/Decisions/refactor-flag-mutation-consolidation/spec.md  ADD  (this file)
+```
+
+---
+
+## Technical Notes
+
+- **No EF Core implications.** `Reconfigure` writes the same three private-setter properties (`IsEnabled`, `StrategyType`, `StrategyConfig`) that `Update` writes today. The `StrategyConfig` backing field + reconciling-getter pattern (KI/lesson 2026-05-07) is untouched.
+- **No DI registration changes.** Nothing in `DependencyInjection.cs` references the deleted methods.
+- **`InternalsVisibleTo("Banderas.Tests")`** already exists on `Banderas.Domain` — test access to the renamed method requires no changes.
+- **`.editorconfig` IDE0008** — the call-site change in `BanderasService.UpdateFlagAsync` does not introduce a `var` declaration. The lessons-learned note from 2026-05-07 about `var` usage stays satisfied; no new style risks.
+- **CSharpier** — no formatting concerns beyond standard one-line renames.
+- **Build gate** — `dotnet build -p:TreatWarningsAsErrors=true` must remain green. There is no realistic CS0618/obsolete pathway; we are deleting, not deprecating.
+- **No ADR required.** The decision is recorded here and in the DDD backlog (which will be checked off by `/post-work`).
+- **Backlog hygiene.** `Docs/Decisions/flag-ddd-analysis-backlog.md` line 80 (`Consolidate SetEnabled() + UpdateStrategy() + Update()`) is checked off during `/post-work`.
+
+---
+
+## Out of Scope
+
+- Adding `Description`, `Tags`, or `Variation` to `Flag` (separate DDD backlog items, future PRs).
+- Splitting `Flag` into a definition aggregate and a `FlagEnvironmentConfig` aggregate (future, larger refactor).
+- Any change to `IBanderasService` or the public HTTP API.
+- Deprecating methods via `[Obsolete]` instead of deleting — the methods have no external consumers; deletion is correct.
+- Adding new domain events (e.g. `FlagReconfigured`) — domain events are Phase 4 observability work.
+- Changing `Archive()` semantics or signature.
+- Changing optimistic concurrency token type or behavior.
+
+---
+
+## Learning Opportunities
+
+1. **Naming as a domain-modeling signal.** The rename from `Update` to `Reconfigure` is the entire point of the refactor — it forces a future reader to think in terms of *the concern* rather than *the fields*. Cheap to do, durable to read. Worth noticing how much of the consolidation lives in the name versus in the deletes.
+2. **Why folding tests is not the same as losing coverage.** Three archived-guard tests that exercise an identical guard against three deleted methods provide zero ongoing value. The single `Reconfigure` archived-guard test exercises the same code path on the only remaining surface. Coverage of the *invariant* is preserved; the redundant *exercise* of it is removed.
+3. **Refactor-only PRs as a confidence signal.** With no public API change and no behavior change, the integration suite must pass *without test changes* (apart from `FlagConcurrencyTokenTests`, which reaches into the domain entity directly as setup). That is the strongest possible signal that the refactor is semantically equivalent.
+
+---
+
+## DX / Tooling Idea
+
+N/A — pure internal refactor; no developer workflow surface is affected.
+
+---
+
+## Definition of Done
+
+- [ ] `Banderas.Domain/Entities/Flag.cs` no longer declares `SetEnabled` or `UpdateStrategy`.
+- [ ] `Banderas.Domain/Entities/Flag.cs` declares `Reconfigure(bool, RolloutStrategy, StrategyConfig)` with the exact body of the former `Update` method, including both invariant guards.
+- [ ] `BanderasService.UpdateFlagAsync` calls `flag.Reconfigure(...)` instead of `flag.Update(...)`.
+- [ ] No file in the repository (excluding this spec) contains the strings `flag.SetEnabled(`, `flag.UpdateStrategy(`, or `flag.Update(`.
+- [ ] `FlagArchivedInvariantTests` contains an archived-guard test for `Reconfigure` and one for `UpdateName` (and `Archive`); tests for `SetEnabled`/`UpdateStrategy` are removed.
+- [ ] `StrategyConfigTests` references `Reconfigure` only; the `UpdateStrategy` mismatch test is removed.
+- [ ] `FlagConcurrencyTokenTests` continues to demonstrate the optimistic concurrency contract using `Reconfigure` (and/or `UpdateName`) — the test still fails on the loser with `DbUpdateConcurrencyException`.
+- [ ] `dotnet build -p:TreatWarningsAsErrors=true` succeeds across all projects.
+- [ ] `dotnet csharpier check .` reports no violations.
+- [ ] `dotnet test` reports all unit tests pass (count may decrease by 3 vs. baseline of 158).
+- [ ] `dotnet test` reports all 54 integration tests pass (count unchanged).
+- [ ] No changes to `Requests/smoke-test.http`; manual smoke confirms PUT `/api/flags/{name}` still returns 200 with the expected `FlagResponse`.
+- [ ] PR description references the DDD backlog item being closed.

--- a/Docs/architecture.md
+++ b/Docs/architecture.md
@@ -174,6 +174,28 @@ access. `InputSanitizer` is the single source of truth for both surfaces.
 - CLI or seed data sanitization (any future non-HTTP input surface must call
   `InputSanitizer` independently)
 
+**Environment sentinel validation — service-level by design:**
+
+The `EnvironmentType.None = 0` sentinel guard is enforced by
+`EnvironmentRules.RequireValid()` at the top of every `IBanderasService` method,
+not at the HTTP boundary. This is the deliberate single source of truth.
+
+- For mutating endpoints (POST/PUT/DELETE), request DTOs also carry a FluentValidation
+  `NotEqual(EnvironmentType.None)` rule — defense-in-depth, but the service-level
+  guard is the authoritative check.
+- For GET endpoints, `EnvironmentType` arrives as a bound query-string parameter
+  with no `IValidator<T>` in the pipeline. `EnvironmentRules.RequireValid()` in the
+  service is the *only* enforcement; `BanderasValidationException` is mapped to
+  `400 ValidationProblemDetails` by `GlobalExceptionMiddleware`.
+
+This is an intentional exception to the "validate at the HTTP boundary before any
+service code runs" convention. Rationale: the check is a one-line enum-sentinel
+guard, duplicating it via a model binder or action filter would split the rule
+across two surfaces without changing observable behavior, and any future non-HTTP
+caller (CLI, seed data, background job) gets the same guard for free. Treat
+`EnvironmentRules` as the canonical environment-validity contract — do not
+reintroduce env-sentinel checks at the controller layer.
+
 ---
 
 ### 3. Application Layer (`IBanderasService`)
@@ -434,7 +456,10 @@ user receiving something they should not.
 ### Domain Integrity
 
 All mutations go through controlled methods to prevent invalid state. No public setters
-on domain entities. `Flag.Update()` sets all related fields atomically.
+on domain entities. `Flag.Reconfigure()` atomically replaces the rollout configuration
+(enabled state, strategy type, strategy config) in a single operation; `Flag.UpdateName()`
+is a distinct rename concern; `Flag.Archive()` is the terminal-state transition. The
+mutation surface is named by concern, not by field.
 
 ---
 

--- a/Docs/current-state.md
+++ b/Docs/current-state.md
@@ -47,12 +47,13 @@
 **Phase 2 — Remove `IsSeeded` from `Flag` Domain Entity (PR TBD): ✅ Complete**
 **Phase 2 — Archived-Flag Integration Test Coverage (PR TBD): ✅ Complete**
 **Phase 2 — Typed StrategyConfig Value Object (PR TBD): ✅ Complete**
+**Phase 2 — Consolidate Flag Mutation Methods by Concern (PR TBD): ✅ Complete**
 
 **Gate Decision:** GO WITH CONDITIONS — AI response validation condition closed
 
 Audit report: `Docs/architecture-review-phase1-report.md`
 
-158 unit tests + 54 integration tests passing (all 212 green).
+153 unit tests + 54 integration tests passing (all 207 green).
 
 ---
 
@@ -61,7 +62,9 @@ Audit report: `Docs/architecture-review-phase1-report.md`
 ### Domain Layer
 
 - `Flag` entity with controlled mutation (private setters, explicit mutation methods)
-- `Flag.Update()` — atomic method that sets enabled state, strategy, and `UpdatedAt`
+- `Flag.Reconfigure(bool, RolloutStrategy, StrategyConfig)` — atomic rollout
+  reconfiguration; single concern-named mutation that replaces the former trio
+  of `SetEnabled` / `UpdateStrategy` / `Update` field-shaped methods
 - Provenance bookkeeping for seeded rows lives at the persistence layer only —
   `IsSeeded` is an EF Core shadow property on the `flags` table, stamped `true`
   by `DatabaseSeeder` after insert and queried via `EF.Property<bool>(f, "IsSeeded")`;
@@ -79,8 +82,8 @@ Audit report: `Docs/architecture-review-phase1-report.md`
   `BanderasValidationException`, `FlagDomainException` (409 Conflict — generic
   domain invariant violation type)
 - `Flag` archived state is terminal — guard clause as the first statement of
-  `SetEnabled`, `UpdateStrategy`, `UpdateName`, `Update`, and `Archive`; throws
-  `FlagDomainException` if `IsArchived` is `true`
+  `Reconfigure`, `UpdateName`, and `Archive`; throws `FlagDomainException` if
+  `IsArchived` is `true`
 
 ### Application Layer
 
@@ -171,15 +174,16 @@ Audit report: `Docs/architecture-review-phase1-report.md`
 
 ### Tests
 
-- 158 unit tests — strategies, evaluator, validators, logging behavior,
+- 153 unit tests — strategies, evaluator, validators, logging behavior,
   prompt sanitization (21), service analysis (5), `Flag` archived-terminal
-  invariants (10), `StrategyConfig` VO (8), config validators (28),
-  `StrategyConfigFactory` (7)
+  invariants (5 — `Reconfigure`, `UpdateName`, `Archive` × archived/non-archived),
+  `StrategyConfig` VO (7), config validators (28), `StrategyConfigFactory` (7)
 - 54 integration tests — all endpoints including `POST /api/flags/health`,
   missing-Azure-OpenAI startup resilience, AI-unavailable 503 behavior,
   semantic AI response validation, archived-flag mutation coverage (PUT/DELETE/evaluate
-  → 404), and `FlagDomainException` → 409 ProblemDetails middleware contract
-- 158 unit + 54 integration passing
+  → 404), `FlagDomainException` → 409 ProblemDetails middleware contract, and
+  optimistic concurrency token via `Flag.Reconfigure` + `Flag.UpdateName`
+- 153 unit + 54 integration passing
 - `InternalsVisibleTo("Banderas.Tests")` and `InternalsVisibleTo("Banderas.Infrastructure")`
   via `Banderas.Domain.csproj`
 - `BanderasServiceLoggingTests` — `NullPromptSanitizer` + `NullAiFlagAnalyzer`
@@ -237,13 +241,16 @@ undocumented status values before any `200 OK` response can leave the AI boundar
 
 ### Immediate Next Tasks
 
-1. Decide whether GET query environment validation should move to the HTTP boundary
-   or remain documented as service-level validation
-2. Continue working through the `Flag` DDD analysis backlog
-   (`Docs/Decisions/flag-ddd-analysis-backlog.md`) — next item: consolidate
-   `SetEnabled` / `UpdateStrategy` / `Update` by concern
-3. Contract tests for API responses
-4. Handle invalid strategy configurations gracefully (defense-in-depth beyond VO validation)
+1. Continue working through the `Flag` DDD analysis backlog
+   (`Docs/Decisions/flag-ddd-analysis-backlog.md`) — next item: introduce
+   `Description` and/or `Tags` as environment-agnostic metadata on the `Flag`
+   definition
+2. Contract tests for API responses
+3. Handle invalid strategy configurations gracefully (defense-in-depth beyond VO validation)
+
+GET query environment validation placement is ratified as service-level
+(`EnvironmentRules.RequireValid` in `BanderasService`) — see
+`Docs/architecture.md` § Validation + Sanitization Layer.
 
 ---
 
@@ -369,6 +376,20 @@ undocumented status values before any `200 OK` response can leave the AI boundar
   on the new `config.ValidatedFor` guard. The rule going forward: after introducing a typed
   VO, audit all test files for null-construction patterns and check `.editorconfig` style
   rules before merging.
+
+- `[2026-05-11] — Name mutation methods after the concern, not the fields`
+
+  `Flag` previously exposed `SetEnabled`, `UpdateStrategy`, and `Update` — three
+  field-shaped mutations of the same domain concern ("change how this flag rolls out").
+  Only the third had a production caller; the other two were dead public surface that
+  invited a partial-mutation bug class (toggle enabled without restating strategy →
+  stale config). Consolidation deleted the field-shaped methods and renamed the
+  surviving one to `Reconfigure(...)`. The name does the load-bearing work: a future
+  reader cannot reach for `SetEnabled` because there is no such method, and the
+  surviving verb declares "full atomic replacement," not "patch one field." The rule
+  going forward: when a domain method's name is a field name plus a verb, ask whether
+  it is one slice of a larger concern; if production never calls it independently,
+  delete it and let the concern-named method be the only surface.
 
 ---
 

--- a/Docs/roadmap.md
+++ b/Docs/roadmap.md
@@ -175,6 +175,8 @@ Every phase of this roadmap builds toward that demo.
         `FlagDomainException` → 409 middleware contract (PR TBD)
   * [x] Convert `StrategyConfig` from raw `string` to typed Value Objects
   * [x] Enforce config/strategy type consistency inside `Flag`
+  * [x] Consolidate mutation methods by concern — delete `SetEnabled` /
+        `UpdateStrategy`, rename `Update` → `Reconfigure`
 * [ ] Contract tests for API responses
 * [ ] Handle invalid strategy configurations gracefully
 * [ ] Test environment-specific behavior edge cases
@@ -258,14 +260,14 @@ Every phase of this roadmap builds toward that demo.
 
 1. Continue strengthening `Flag` domain invariants — typed `StrategyConfig` VO and
    config/strategy consistency are done; next backlog item: consolidate mutation methods
-2. Decide whether GET query environment validation should move earlier or remain
-   explicitly documented as service-level validation
-3. Continue working through the `Flag` DDD analysis backlog
+2. Continue working through the `Flag` DDD analysis backlog
+3. Contract tests for API responses
 
 **Phase 2 progress: archived state terminal (PR #59), `IsSeeded` removed from domain,
 archived-flag integration test coverage complete, typed `StrategyConfig` Value Object
-with config/strategy consistency enforcement complete. Next: contract tests for API
-responses.**
+with config/strategy consistency enforcement complete, `Flag` mutation methods
+consolidated by concern (`SetEnabled` / `UpdateStrategy` / `Update` → `Reconfigure`).
+Next: contract tests for API responses.**
 
 ---
 


### PR DESCRIPTION
## Summary

Replaces the trio `Flag.SetEnabled` / `Flag.UpdateStrategy` / `Flag.Update` with a single concern-named mutation `Flag.Reconfigure(bool, RolloutStrategy, StrategyConfig)`. The two field-shaped methods had no production callers — deleting them removes a partial-mutation bug class (toggle enabled while leaving a now-mismatched strategy behind). The atomic `Update` method is renamed to `Reconfigure` to declare full replacement, not partial patching. `UpdateName` and `Archive` are unchanged. Public HTTP API, DTOs, and `IBanderasService` signatures are byte-for-byte identical to before.

## Changes in this PR

- **Domain + Application** — `Flag.cs` deletes `SetEnabled` and `UpdateStrategy`; renames `Update` → `Reconfigure` with a concern-named XML doc. `BanderasService.UpdateFlagAsync` adopts the new method name (one line).
- **Tests** — drop deleted-method tests, rename `Update*` test methods to `Reconfigure*`, remove the redundant `UpdateStrategy` mismatch test, and update the optimistic concurrency integration test to race `Reconfigure` against `UpdateName`.
- **Docs** — spec + implementation notes added under `Docs/Decisions/refactor-flag-mutation-consolidation/`. Foundation docs updated: `architecture.md` (Domain Integrity principle + GET-query environment-validation ratification), `current-state.md` (phase status, archived-terminal note, test counts, 2026-05-11 Lessons Learned), `roadmap.md` (Phase 2 checkbox + progress sentence), `flag-ddd-analysis-backlog.md` (backlog item checked off).

## Spec

`Docs/Decisions/refactor-flag-mutation-consolidation/spec.md`

## Implementation Notes

`Docs/Decisions/refactor-flag-mutation-consolidation/implementation-notes.md`

## Definition of Done

- [x] `SetEnabled` and `UpdateStrategy` removed from `Flag.cs`
- [x] `Update` renamed to `Reconfigure`; XML doc rewritten to name the concern
- [x] `BanderasService.UpdateFlagAsync` calls `flag.Reconfigure(...)`
- [x] No file in repo (excluding the spec) references `flag.SetEnabled(`, `flag.UpdateStrategy(`, or `flag.Update(` — verified by grep
- [x] `FlagArchivedInvariantTests` covers `Reconfigure`, `UpdateName`, `Archive`; deleted method tests removed
- [x] `StrategyConfigTests` references `Reconfigure` only; redundant `UpdateStrategy` mismatch test removed
- [x] `FlagConcurrencyTokenTests` continues to demonstrate the optimistic concurrency contract
- [x] `dotnet build -p:TreatWarningsAsErrors=true` succeeds across all projects (0 warnings / 0 errors)
- [x] `dotnet csharpier check .` reports no violations (104 files checked)
- [x] All unit tests pass (153/153 — 5 fewer than baseline, all due to deleted-method coverage being folded)
- [x] All integration tests pass (54/54, count unchanged)
- [x] `Requests/smoke-test.http` unchanged; PUT `/api/flags/{name}` returns the same `200 OK` `FlagResponse`
- [x] DDD backlog item `Consolidate SetEnabled() + UpdateStrategy() + Update()` checked off in `Docs/Decisions/flag-ddd-analysis-backlog.md`

## Testing

**Domain unit tests** (cover AC-1 through AC-5):

```bash
dotnet test Banderas.Tests/Banderas.Tests.csproj \
  --filter "FullyQualifiedName~FlagArchivedInvariantTests|FullyQualifiedName~StrategyConfigTests"
```

Expected: all archived-guard, success, and config-mismatch tests pass; no test references `SetEnabled` or `UpdateStrategy`.

**Integration suite** (covers AC-6 byte-for-byte API parity and AC-7 optimistic concurrency):

```bash
dotnet test Banderas.Tests.Integration/Banderas.Tests.Integration.csproj
```

Expected: 54/54 green. `FlagConcurrencyTokenTests.ConcurrentUpdate_SecondSave_ThrowsFlagConcurrencyExceptionAsync` demonstrates the optimistic concurrency contract via `Reconfigure` + `UpdateName`.

**Manual smoke** (no expected change vs. baseline):

```bash
curl -X PUT http://localhost:5051/api/flags/checkout-flow \
  -H "Content-Type: application/json" \
  -d '{"environment":"Development","isEnabled":true,"strategyType":"None","strategyConfig":null}'
```

Expected: `200 OK` with `FlagResponse` body, identical to the pre-refactor baseline.

**Static check that no caller revived a deleted method:**

```bash
grep -rn "\.SetEnabled(\|\.UpdateStrategy(\|flag\.Update(" --include="*.cs" .
```

Expected: zero hits.
